### PR TITLE
#9: Experimental support for obtaining an analysed text as a UIMA CAS

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -300,6 +300,10 @@ class Pipeline:
     # Ignoring errors as linter (compiler) cannot resolve dynamically loaded lib (with type:ignore for mypy) and (noinspection PyProtectedMember for pycharm)
     @experimental_api
     def analyse_text_to_cas(self, source: Union[IO, str], **kwargs) -> "Cas":  # type: ignore
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear. Processes text using a pipeline and returns the result
+        as a UIMA CAS. Calling this method requires that the DKPro Cassis Python library has been installed.
+        """
         # noinspection PyProtectedMember
         return importlib.import_module("cassis").load_cas_from_xmi(  # type: ignore
             self.project.client._analyse_text_xmi(self.project.name, self.name, source, **kwargs),
@@ -309,6 +313,10 @@ class Pipeline:
     # Ignoring errors as linter (compiler) cannot resolve dynamically loaded lib (with type:ignore for mypy) and (noinspection PyProtectedMember for pycharm)
     @experimental_api
     def get_type_system(self) -> "TypeSystem":  # type: ignore
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear. Processes text using a pipeline and returns the result
+        as a UIMA CAS. Calling this method requires that the DKPro Cassis Python library has been installed.
+        """
         if self.cached_type_system is None:
             # noinspection PyProtectedMember
             self.cached_type_system = importlib.import_module("cassis").load_typesystem(  # type: ignore

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -52,6 +52,13 @@ TERMINOLOGY_EXPORTER_SOLR_AUTO_SUGGEST_XML = "Solr Autosuggest XML Exporter"
 TERMINOLOGY_EXPORTER_CONCEPT_DICTIONARY_XML = "Concept Dictionary XML Exporter"
 
 
+def experimental_api(original_function):
+    def new_function(*args, **kwargs):
+        return original_function(*args, **kwargs)
+
+    return new_function
+
+
 class OperationNotSupported(Exception):
     """Raised when the REST API does not support a given operation."""
 
@@ -289,6 +296,25 @@ class Pipeline:
         self.project.client._set_pipeline_configuration(self.project.name, self.name, configuration)
         if was_running_before_configuration_change:
             self.ensure_started()
+
+    # Ignoring errors as linter (compiler) cannot resolve dynamically loaded lib (with type:ignore for mypy) and (noinspection PyProtectedMember for pycharm)
+    @experimental_api
+    def analyse_text_to_cas(self, source: Union[IO, str], **kwargs) -> "Cas":  # type: ignore
+        # noinspection PyProtectedMember
+        return importlib.import_module("cassis").load_cas_from_xmi(  # type: ignore
+            self.project.client._analyse_text_xmi(self.project.name, self.name, source, **kwargs),
+            typesystem=self.get_type_system(),
+        )
+
+    # Ignoring errors as linter (compiler) cannot resolve dynamically loaded lib (with type:ignore for mypy) and (noinspection PyProtectedMember for pycharm)
+    @experimental_api
+    def get_type_system(self) -> "TypeSystem":  # type: ignore
+        if self.cached_type_system is None:
+            # noinspection PyProtectedMember
+            self.cached_type_system = importlib.import_module("cassis").load_typesystem(  # type: ignore
+                self.project.client._get_pipeline_type_system(self.project.name, self.name)
+            )
+        return self.cached_type_system
 
 
 class Terminology:
@@ -999,6 +1025,43 @@ class Client:
             headers={HEADER_CONTENT_TYPE: MEDIA_TYPE_TEXT_PLAIN_UTF8},
         )
         return response["payload"]
+
+    @experimental_api
+    def _analyse_text_xmi(
+        self,
+        project: str,
+        pipeline: str,
+        source: Union[IO, str],
+        annotation_types: str = None,
+        language: str = "de",
+    ) -> str:
+        data: IO = BytesIO(source.encode(ENCODING_UTF_8)) if isinstance(source, str) else source
+
+        return str(
+            self.__request_with_bytes_response(
+                "post",
+                f"/v1/textanalysis/projects/{project}/pipelines/{pipeline}/analyseText",
+                data=data,
+                params={"annotationTypes": annotation_types, "language": language},
+                headers={
+                    HEADER_CONTENT_TYPE: MEDIA_TYPE_TEXT_PLAIN_UTF8,
+                    HEADER_ACCEPT: MEDIA_TYPE_APPLICATION_XMI,
+                },
+            ),
+            ENCODING_UTF_8,
+        )
+
+    @experimental_api
+    def _get_pipeline_type_system(self, project: str, pipeline: str) -> str:
+        return str(
+            self.__request_with_bytes_response(
+                "get",
+                f"/v1/textanalysis/projects/{project}/pipelines/{pipeline}/exportTypeSystem",
+                params={"annotationTypes": "*"},
+                headers={HEADER_ACCEPT: MEDIA_TYPE_APPLICATION_XML},
+            ),
+            ENCODING_UTF_8,
+        )
 
     @staticmethod
     def __handle_error(response):

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -35,7 +35,7 @@ HEADER_ACCEPT = "Accept"
 HEADER_CONTENT_TYPE = "Content-Type"
 
 MEDIA_TYPE_ANY = "*/*"
-MEDIA_TYPE_APPLICATION_XMI = "application/vnd.xmi+xml"
+MEDIA_TYPE_APPLICATION_XMI = "application/vnd.uima.cas+xmi"
 MEDIA_TYPE_APPLICATION_JSON = "application/json"
 MEDIA_TYPE_APPLICATION_XML = "application/xml"
 MEDIA_TYPE_TEXT_PLAIN_UTF8 = "text/plain; charset=utf-8"
@@ -1040,7 +1040,7 @@ class Client:
         return str(
             self.__request_with_bytes_response(
                 "post",
-                f"/v1/textanalysis/projects/{project}/pipelines/{pipeline}/analyseText",
+                f"/experimental/textanalysis/projects/{project}/pipelines/{pipeline}/debugAnalyseText",
                 data=data,
                 params={"annotationTypes": annotation_types, "language": language},
                 headers={
@@ -1056,7 +1056,7 @@ class Client:
         return str(
             self.__request_with_bytes_response(
                 "get",
-                f"/v1/textanalysis/projects/{project}/pipelines/{pipeline}/exportTypeSystem",
+                f"/experimental/textanalysis/projects/{project}/pipelines/{pipeline}/debugTypesystem",
                 params={"annotationTypes": "*"},
                 headers={HEADER_ACCEPT: MEDIA_TYPE_APPLICATION_XML},
             ),


### PR DESCRIPTION
- Adds support for the experimental support for obtaining pipelines results as an UIMA CAS
- Adds an optional runtime dependency on DKPro Cassis - the import is only triggered if the experimental API calls are triggered
- 