### PR TITLE
Issue #8: Change language default value to None

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -951,7 +951,7 @@ class Client:
         pipeline: str,
         source: Union[Path, IO, str],
         annotation_types: str = None,
-        language: str = "de",
+        language: str = None,
     ) -> dict:
         if isinstance(source, Path):
             with source.open("r", encoding=ENCODING_UTF_8) as file:
@@ -974,7 +974,7 @@ class Client:
         pipeline: str,
         source: Union[Path, IO, str],
         annotation_types: str = None,
-        language: str = "de",
+        language: str = None,
     ) -> dict:
         if isinstance(source, Path):
             with source.open("r", encoding=ENCODING_UTF_8) as file:


### PR DESCRIPTION
Referring to our discussion in #8, I feel like the cleanest solution is to keep language as an kwarg with default value None.
I would rather choose None instead of "Auto", since the value "Auto" may suggest that we can detect languages automatically in every pipeline. None just omits the request parameter, which is a sensible choice imho.
Having it as an arg would raise awareness, but would be awkward when interacting with pipelines that only use one language and should not receive any language parameter.

But I'm open to alternatives, ofc.

I feel like the most useful place for documenting possible parameter values is in the documentation of the pipelines or annotators (same goes for the documentation of possible annotationTypes).

I wasn't sure how to unit test this with a mock, if at all. Maybe you can give me a hint there.

