### PR TITLE
Adds a documentation section to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ Documentation
 -------------
 
 To get an overview over the methods provided with the client and the corresponding documentation, we refer to our `readthedocs API reference <https://averbis-python-api.readthedocs.io/en/latest/index.html>`_.
+
 Moreover, we will provide a number of example jupyter notebooks that showcase the usage of the client to solve different use cases in an upcoming release.
 
 

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,12 @@ The library can be installed easily via :code:`pip`
 
   pip install averbis-python-api
 
+Documentation
+-------------
+
+To get an overview over the methods provided with the client and the corresponding documentation, we refer to our `readthedocs API reference <https://averbis-python-api.readthedocs.io/en/latest/index.html>`_.
+Moreover, we will provide a number of example jupyter notebooks that showcase the usage of the client to solve different use cases in an upcoming release.
+
 
 Usage
 -----


### PR DESCRIPTION
So far the only link to the readthedocs was in the little "readthedocs" tag on github, which is not that obvious imho.
Hence, the added section. It also contains a little teaser to the example notebooks, which are to come. Here we could also add a link to the google colab notebook in the future, which should come together with the example jupyter notebooks.