### PR TITLE
Issue #19: Configuration Schema 2.0 Support

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -234,7 +234,11 @@ class Pipeline:
 
         :return: An iterator over the results produced by the pipeline.
         """
-        pipeline_instances = self.get_configuration()["analysisEnginePoolSize"]
+        if self.project.client.spec_version.startswith("5."):
+            pipeline_instances = self.get_configuration()["analysisEnginePoolSize"]
+        else:
+            pipeline_instances = self.get_configuration()["numberOfInstances"]
+
         if parallelism < 0:
             parallel_request_count = max(pipeline_instances + parallelism, 1)
         elif parallelism > 0:
@@ -469,15 +473,23 @@ class Project:
 
         :return: The pipeline.
         """
+
+        # The pipeline name parameter differs between schemaVersion 1.x ("name") and 2.x ("pipelineName")
+        if configuration["schemaVersion"].startswith("1."):
+            pipeline_name_key = "name"
+        else:
+            pipeline_name_key = "pipelineName"
+
         if name is not None:
             cfg = copy.deepcopy(configuration)
-            cfg["name"] = name
+            cfg[pipeline_name_key] = name
         else:
             cfg = configuration
+            name = cfg[pipeline_name_key]
 
         self.client._create_pipeline(self.name, cfg)
-        new_pipeline = Pipeline(self, cfg["name"])
-        self.__cached_pipelines[cfg["name"]] = new_pipeline
+        new_pipeline = Pipeline(self, name)
+        self.__cached_pipelines[name] = new_pipeline
         return new_pipeline
 
     def create_terminology(
@@ -553,12 +565,12 @@ class Client:
         self,
         url_or_id: str,
         api_token: str = None,
-        verify_ssl: Union[str, bool] = None,
+        verify_ssl: Union[str, bool] = True,
         settings: Union[str, Path, dict] = None,
     ):
         self.__logger = logging.getLogger(self.__class__.__module__ + "." + self.__class__.__name__)
-        self._api_token = None
-        self._verify_ssl = True
+        self._api_token = api_token
+        self._verify_ssl = verify_ssl
 
         if isinstance(settings, dict):
             self._settings = settings
@@ -572,11 +584,8 @@ class Client:
                 self._apply_profile("*")
             self._apply_profile(url_or_id)
 
-        if api_token:
-            self._api_token = api_token
-
-        if verify_ssl:
-            self.verify_ssl = api_token
+        self.build_info = self.get_build_info()
+        self.spec_version = self.build_info["specVersion"]
 
     def _exists_profile(self, profile: str):
         return (

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,73 @@
+import os
+
+import pytest
+
+from averbis import Client
+
+URL_BASE_ID = "https://localhost:8080/information-discovery"
+URL_BASE_HD = "https://localhost:8080/health-discovery"
+API_BASE = URL_BASE_ID + "/rest/v1"
+TEST_DIRECTORY = os.path.dirname(__file__)
+
+
+## Mock different platforms. The difference between the platforms is in the URL and in the specVersion number.
+
+@pytest.fixture()
+def requests_mock_hd5(requests_mock):
+    requests_mock.get(
+        f"{URL_BASE_HD + '/rest/v1'}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "5.33.0", "buildNumber": ""}, "errorMessages": []},
+    )
+
+
+@pytest.fixture()
+def requests_mock_hd6(requests_mock):
+    requests_mock.get(
+        f"{URL_BASE_HD + '/rest/v1'}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "6.0.0", "buildNumber": ""}, "errorMessages": []},
+    )
+
+
+@pytest.fixture()
+def requests_mock_id5(requests_mock):
+    requests_mock.get(
+        f"{URL_BASE_ID + '/rest/v1'}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "5.33.0", "buildNumber": ""}, "errorMessages": []},
+    )
+
+
+@pytest.fixture()
+def requests_mock_id6(requests_mock):
+    requests_mock.get(
+        f"{URL_BASE_ID + '/rest/v1'}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "6.0.0", "buildNumber": ""}, "errorMessages": []},
+    )
+
+
+## Different clients based on the above platforms
+
+# Tests that should work for all platform versions
+@pytest.fixture(params=["5.33.0", "6.0.0"])
+def client(request, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": request.param, "buildNumber": ""}, "errorMessages": []},
+    )
+    return Client(URL_BASE_ID)
+
+
+# Tests that should work in platform version 5
+@pytest.fixture
+def client_version_5(requests_mock_id5):
+    return Client(URL_BASE_ID)
+
+
+# Tests that should work in platform version 6
+@pytest.fixture()
+def client_version_6(requests_mock_id6):
+    return Client(URL_BASE_ID)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -31,6 +31,7 @@ TEST_DIRECTORY = os.path.dirname(__file__)
 
 ## Mock different platforms. The difference between the platforms is in the URL and in the specVersion number.
 
+
 @pytest.fixture()
 def requests_mock_hd5(requests_mock):
     requests_mock.get(

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,22 @@
+#
+# Copyright (c) 2021 Averbis GmbH.
+#
+# This file is part of Averbis Python API.
+# See https://www.averbis.com for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 import os
 
 import pytest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -627,7 +627,10 @@ def test_select(client, requests_mock):
 
 
 def test_with_settings_file(requests_mock_hd6):
-    client = Client("localhost-hd", settings=os.path.join(TEST_DIRECTORY, "resources/settings/client-settings.json"))
+    client = Client(
+        "localhost-hd",
+        settings=os.path.join(TEST_DIRECTORY, "resources/settings/client-settings.json"),
+    )
 
     assert client._url == "https://localhost:8080/health-discovery"
     assert client._api_token == "dummy-token"
@@ -636,7 +639,10 @@ def test_with_settings_file(requests_mock_hd6):
 
 def test_with_settings_file_with_defaults_hd(requests_mock_hd6):
     hd_client = Client(
-        "localhost-hd", settings=os.path.join(TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json")
+        "localhost-hd",
+        settings=os.path.join(
+            TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json"
+        ),
     )
 
     assert hd_client._url == "https://localhost:8080/health-discovery"
@@ -646,7 +652,10 @@ def test_with_settings_file_with_defaults_hd(requests_mock_hd6):
 
 def test_with_settings_file_with_defaults_id(requests_mock_id6):
     id_client = Client(
-        "localhost-id", settings=os.path.join(TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json")
+        "localhost-id",
+        settings=os.path.join(
+            TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json"
+        ),
     )
 
     assert id_client._url == "https://localhost:8080/information-discovery"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,8 +19,7 @@
 #
 import logging
 
-import pytest
-from averbis import Client, Pipeline, Project
+from averbis import Pipeline, Project
 from averbis.core import (
     OperationNotSupported,
     TERMINOLOGY_EXPORTER_OBO_1_4,
@@ -28,18 +27,12 @@ from averbis.core import (
     ENCODING_UTF_8,
     DOCUMENT_IMPORTER_TEXT,
 )
-import os
+from tests.fixtures import *
 
-URL_BASE = "http://localhost:8080"
-API_BASE = URL_BASE + "/rest/v1"
 TEST_API_TOKEN = "I-am-a-dummy-API-token"
-
-logging.basicConfig(level=logging.INFO)
 TEST_DIRECTORY = os.path.dirname(__file__)
 
-@pytest.fixture
-def client():
-    return Client(URL_BASE)
+logging.basicConfig(level=logging.INFO)
 
 
 def test_default_headers(client):
@@ -147,7 +140,7 @@ def test_get_build_info(client, requests_mock):
 
 
 def test_create_project(client, requests_mock):
-    def callback(request, context):
+    def callback(request, _):
         return {
             "payload": {
                 "id": 93498,
@@ -198,9 +191,29 @@ def test_create_pipeline(client, requests_mock):
         # ... truncated ...
     }
 
-    response = client._create_pipeline("LoadTesting", configuration)
+    new_pipeline = client._create_pipeline("LoadTesting", configuration)
 
-    assert response is None
+    assert new_pipeline is None
+
+
+def test_create_pipeline_schema_version_two(client, requests_mock):
+    requests_mock.post(
+        f"{API_BASE}/textanalysis/projects/LoadTesting/pipelines",
+        headers={"Content-Type": "application/json"},
+        json={"payload": None, "errorMessages": []},
+    )
+
+    configuration = {
+        "schemaVersion": "2.0",
+        "pipelineName": "discharge",
+        "description": None,
+        "numberOfInstances": 2,
+        # ... truncated ...
+    }
+
+    new_pipeline = client._create_pipeline("LoadTesting", configuration)
+
+    assert new_pipeline is None
 
 
 def test_delete_pipeline(client):
@@ -485,7 +498,7 @@ def test_analyse_text(client, requests_mock):
     assert response[0]["coveredText"] == "Appendizitis"
 
 
-def test_analyse_texts_with_some_working_and_some_failing(client, requests_mock):
+def test_analyse_texts_with_some_working_and_some_failing(client_version_5, requests_mock):
     requests_mock.get(
         f"{API_BASE}/textanalysis/projects/LoadTesting/pipelines/discharge/configuration",
         headers={"Content-Type": "application/json"},
@@ -495,7 +508,7 @@ def test_analyse_texts_with_some_working_and_some_failing(client, requests_mock)
         },
     )
 
-    def callback(request, context):
+    def callback(request, _):
         doc_text = request.text.read().decode("utf-8")
         if doc_text == "works":
             return {
@@ -522,7 +535,7 @@ def test_analyse_texts_with_some_working_and_some_failing(client, requests_mock)
         json=callback,
     )
 
-    pipeline = Pipeline(Project(client, "LoadTesting"), "discharge")
+    pipeline = Pipeline(Project(client_version_5, "LoadTesting"), "discharge")
     results = list(pipeline.analyse_texts(["works", "fails"]))
 
     assert results[0].successful() is True
@@ -613,25 +626,27 @@ def test_select(client, requests_mock):
     assert "solrResponse" in response
 
 
-def test_with_settings_file():
-    client = Client("localhost-hd", settings= os.path.join(TEST_DIRECTORY, "resources/settings/client-settings.json"))
+def test_with_settings_file(requests_mock_hd6):
+    client = Client("localhost-hd", settings=os.path.join(TEST_DIRECTORY, "resources/settings/client-settings.json"))
 
     assert client._url == "https://localhost:8080/health-discovery"
     assert client._api_token == "dummy-token"
     assert client._verify_ssl is False
 
 
-def test_with_settings_file_with_defaults():
+def test_with_settings_file_with_defaults_hd(requests_mock_hd6):
     hd_client = Client(
-        "localhost-hd", settings= os.path.join(TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json")
+        "localhost-hd", settings=os.path.join(TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json")
     )
 
     assert hd_client._url == "https://localhost:8080/health-discovery"
     assert hd_client._api_token == "dummy-token"
     assert hd_client._verify_ssl == "caRoot.pem"
 
+
+def test_with_settings_file_with_defaults_id(requests_mock_id6):
     id_client = Client(
-        "localhost-id", settings= os.path.join(TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json")
+        "localhost-id", settings=os.path.join(TEST_DIRECTORY, "resources/settings/client-settings-with-defaults.json")
     )
 
     assert id_client._url == "https://localhost:8080/information-discovery"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -69,7 +69,7 @@ def pipeline_analyse_text_mock(client, requests_mock):
         },
     )
 
-    def callback(request, _):
+    def callback(request, _content):
         doc_text = request.text.read().decode("utf-8")
         return {
             "payload": [
@@ -166,7 +166,7 @@ class PipelineEndpointMock:
         self.state_locked = locked
         self.requested_state_pipeline_state_message = pipeline_state_message
 
-    def info_callback(self, _, __):
+    def info_callback(self, _request, _content):
         if (
             not self.state_locked
             and self.last_state_change_request + self.change_state_after < time.time()
@@ -189,12 +189,12 @@ class PipelineEndpointMock:
             "errorMessages": [],
         }
 
-    def start_callback(self, _, __):
+    def start_callback(self, _request, _content):
         self.last_state_change_request = time.time()
         self.requested_state = Pipeline.STATE_STARTED
         return {"payload": {}, "errorMessages": []}
 
-    def stop_callback(self, _, __):
+    def stop_callback(self, _request, _content):
         self.last_state_change_request = time.time()
         self.requested_state = Pipeline.STATE_STOPPED
         return {"payload": {}, "errorMessages": []}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -18,25 +18,14 @@
 #
 #
 import logging
-import os
+import time
 from pathlib import Path
 
-import pytest
-import time
-
-from averbis import Client, Project, Pipeline
+from averbis import Project, Pipeline
 from averbis.core import OperationTimeoutError
-
-URL_BASE = "http://localhost:8080"
-API_BASE = URL_BASE + "/rest/v1"
-TEST_DIRECTORY = os.path.dirname(__file__)
+from tests.fixtures import *
 
 logging.basicConfig(level=logging.INFO)
-
-
-@pytest.fixture
-def client() -> Client:
-    return Client(URL_BASE)
 
 
 @pytest.fixture
@@ -63,18 +52,24 @@ def pipeline_requests_mock(pipeline_endpoint_behavior_mock, requests_mock):
     )
 
 
-@pytest.fixture()
-def pipeline_analyse_text_mock(requests_mock):
+@pytest.fixture
+def pipeline_analyse_text_mock(client, requests_mock):
+    # In the pipeline configuration, the name for the number of instances differs between platform version 5 and 6.
+    if client.spec_version.startswith("5."):
+        payload = {"analysisEnginePoolSize": 4}
+    else:
+        payload = {"numberOfInstances": 4}
+
     requests_mock.get(
         f"{API_BASE}/textanalysis/projects/LoadTesting/pipelines/discharge/configuration",
         headers={"Content-Type": "application/json"},
         json={
-            "payload": {"analysisEnginePoolSize": 4},
+            "payload": payload,
             "errorMessages": [],
         },
     )
 
-    def callback(request, context):
+    def callback(request, _):
         doc_text = request.text.read().decode("utf-8")
         return {
             "payload": [
@@ -171,7 +166,7 @@ class PipelineEndpointMock:
         self.state_locked = locked
         self.requested_state_pipeline_state_message = pipeline_state_message
 
-    def info_callback(self, request, context):
+    def info_callback(self, _, __):
         if (
             not self.state_locked
             and self.last_state_change_request + self.change_state_after < time.time()
@@ -194,12 +189,12 @@ class PipelineEndpointMock:
             "errorMessages": [],
         }
 
-    def start_callback(self, request, context):
+    def start_callback(self, _, __):
         self.last_state_change_request = time.time()
         self.requested_state = Pipeline.STATE_STARTED
         return {"payload": {}, "errorMessages": []}
 
-    def stop_callback(self, request, context):
+    def stop_callback(self, _, __):
         self.last_state_change_request = time.time()
         self.requested_state = Pipeline.STATE_STOPPED
         return {"payload": {}, "errorMessages": []}
@@ -224,6 +219,19 @@ def test_analyse_texts_with_paths(client, pipeline_analyse_text_mock):
 
 
 def test_analyse_texts_with_files(client, pipeline_analyse_text_mock):
+    pipeline = Pipeline(Project(client, "LoadTesting"), "discharge")
+    file1_path = os.path.join(TEST_DIRECTORY, "resources/texts/text1.txt")
+    file2_path = os.path.join(TEST_DIRECTORY, "resources/texts/text2.txt")
+
+    with open(file1_path, "rb") as file1, open(file2_path, "rb") as file2:
+        results = pipeline.analyse_texts([file1, file2])
+        sources = [result.source.replace(os.sep, "/") for result in results]
+
+    assert sources[0].endswith("tests/resources/texts/text1.txt")
+    assert sources[1].endswith("tests/resources/texts/text2.txt")
+
+
+def test_analyse_texts_(client, pipeline_analyse_text_mock):
     pipeline = Pipeline(Project(client, "LoadTesting"), "discharge")
     file1_path = os.path.join(TEST_DIRECTORY, "resources/texts/text1.txt")
     file2_path = os.path.join(TEST_DIRECTORY, "resources/texts/text2.txt")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -19,34 +19,54 @@
 #
 import logging
 
-import pytest
-
-from averbis import Project, Client
-
-URL_BASE = "http://localhost:8080"
-API_BASE = URL_BASE + "/rest/v1"
+from tests.fixtures import *
 
 logging.basicConfig(level=logging.INFO)
 
 
-@pytest.fixture
-def project() -> Project:
-    return Client(URL_BASE).get_project("LoadTesting")
-
-
-def test_that_create_pipeline_accepts_name_override(project, requests_mock):
+def test_that_create_pipeline_accepts_name_override(client_version_5, requests_mock):
+    project = client_version_5.get_project("LoadTesting")
     requests_mock.post(
         f"{API_BASE}/textanalysis/projects/LoadTesting/pipelines",
         headers={"Content-Type": "application/json"},
         json={"payload": None, "errorMessages": []},
     )
-    configuration = {"name": "discharge"}
+    configuration = {"pipelineName": "discharge", "schemaVersion": "1.3"}
     pipeline = project.create_pipeline(configuration, name="discharge2")
 
     assert pipeline.name == "discharge2"
 
 
-def test_that_get_pipeline_returns_same_instance_on_consecutive_calls(project, requests_mock):
+def test_that_create_pipeline_schema_1(client_version_5, requests_mock):
+    # The pipeline name parameter is "name" in version 5 and "pipelineName" in version 6
+    project = client_version_5.get_project("LoadTesting")
+    requests_mock.post(
+        f"{API_BASE}/textanalysis/projects/LoadTesting/pipelines",
+        headers={"Content-Type": "application/json"},
+        json={"payload": None, "errorMessages": []},
+    )
+    configuration = {"name": "discharge-new", "schemaVersion": "1.3"}
+    pipeline = project.create_pipeline(configuration)
+
+    assert pipeline.name == "discharge-new"
+
+
+def test_that_create_pipeline_schema_2(client_version_6, requests_mock):
+    # The pipeline name parameter is "name" in version 5 and "pipelineName" in version 6
+    project = client_version_6.get_project("LoadTesting")
+    requests_mock.post(
+        f"{API_BASE}/textanalysis/projects/LoadTesting/pipelines",
+        headers={"Content-Type": "application/json"},
+        json={"payload": None, "errorMessages": []},
+    )
+    configuration = {"pipelineName": "discharge-new", "schemaVersion": "2.0"}
+    pipeline = project.create_pipeline(configuration)
+
+    assert pipeline.name == "discharge-new"
+
+
+def test_that_get_pipeline_returns_same_instance_on_consecutive_calls(client):
+    project = client.get_project("LoadTesting")
     pipeline1 = project.get_pipeline("discharge")
     pipeline2 = project.get_pipeline("discharge")
 


### PR DESCRIPTION
- Introduced new variable spec_version in Client that holds information about the current platform version (e.g. "5.33.0" or "6.0.0")
- Added new fixtures that can be used to create a client based on version 5.33.0 or based on version 6.0.0 or based on both. 
- Moved client fixtures in and constants (URLs) in tests to fixtures.py
- Rest Client change #1: Setting pipeline name parameter based on schemaVersion
- Rest Client change #2: Getting number of instances based on platform version
- Added tests for both client changes
- (Other) Small code fixes regarding _verify_ssl and _api_token in Client
- (Other) Renamed unused parameters to "_" such that there are no warnings in tests