### PR TITLE
Feature/20 support experimental endpoints delete export

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -567,6 +567,25 @@ class Project:
         # noinspection PyProtectedMember
         return self.client._select(self.name, query, **kwargs)
 
+    @experimental_api
+    def export_text_analysis(
+        self, document_sources: str, process: str, annotation_types: str = None
+    ) -> dict:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear. Exports a given text analysis process as a json.
+
+        :return: The raw payload of the server response. Future versions of this library may return a better-suited
+         representation.
+        """
+        if self.client.spec_version.startswith("5."):
+            raise OperationNotSupported(
+                "Text analysis export is not supported for platform version 5.x, it is only supported from 6.x onwards."
+            )
+        # noinspection PyProtectedMember
+        return self.client._export_text_analysis(
+            self.name, document_sources, process, annotation_types
+        )
+
 
 class Client:
     def __init__(
@@ -1052,6 +1071,21 @@ class Client:
             f"/v1/search/projects/{project}/select",
             params={"q": q, **kwargs},
             headers={HEADER_CONTENT_TYPE: MEDIA_TYPE_TEXT_PLAIN_UTF8},
+        )
+        return response["payload"]
+
+    @experimental_api
+    def _export_text_analysis(
+        self, project: str, document_sources: str, process: str, annotation_types: str = None
+    ):
+        """
+        Use Project.export_text_analysis() instead.
+        """
+        response = self.__request(
+            "get",
+            f"/experimental/textanalysis/projects/{project}/documentSources/{document_sources}/processes/{process}/export",
+            params={"annotationTypes": annotation_types},
+            headers={HEADER_ACCEPT: MEDIA_TYPE_APPLICATION_JSON},
         )
         return response["payload"]
 

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -594,6 +594,7 @@ class Client:
         api_token: str = None,
         verify_ssl: Union[str, bool] = True,
         settings: Union[str, Path, dict] = None,
+        regenerate_api_token: bool = False,
     ):
         self.__logger = logging.getLogger(self.__class__.__module__ + "." + self.__class__.__name__)
         self._api_token = api_token
@@ -611,6 +612,15 @@ class Client:
                 self._apply_profile("*")
             self._apply_profile(url_or_id)
 
+        if self._api_token is None:
+            if regenerate_api_token:
+                self.regenerate_api_token("admin", "admin")
+            else:
+                raise Exception(
+                    "An API Token is required for initializing the Client.\n"
+                    + "You can either pass it directly with: Client(url,api_token=your_token) or you can\n"
+                    + "generate a new API token for the standard admin user with: Client(url, regenerate_api_token=True)."
+                )
         self.build_info = self.get_build_info()
         self.spec_version = self.build_info["specVersion"]
 

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -200,15 +200,21 @@ class Pipeline:
         # noinspection PyProtectedMember
         return self.project.client._get_pipeline_info(self.project.name, self.name)
 
-    def delete(self) -> None:
+    @experimental_api
+    def delete(self) -> dict:
         """
-        Delete the pipeline from the server.
+        HIGHLY EXPERIMENTAL API - may soon change or disappear. Deletes an existing pipeline from the server.
 
         :return: The raw payload of the server response. Future versions of this library may return a better-suited
                  representation.
         """
+        if self.project.client.spec_version.startswith("5."):
+            raise OperationNotSupported(
+                "Deleting pipelines is not supported by the REST API in platform version 5.x, but only from 6.x onwards."
+            )
+
         # noinspection PyProtectedMember
-        self.project.client._delete_pipeline(self.project.name, self.name)
+        return self.project.client._delete_pipeline(self.project.name, self.name)
 
     def is_started(self) -> bool:
         """
@@ -931,11 +937,15 @@ class Client:
         )
         return response["payload"]
 
-    def _delete_pipeline(self, project: str, pipeline: str) -> None:
+    @experimental_api
+    def _delete_pipeline(self, project: str, pipeline: str) -> dict:
         """
         Use Pipeline.delete() instead.
         """
-        raise OperationNotSupported("Deleting pipelines is not supported by the REST API yet")
+        response = self.__request(
+            "delete", f"/experimental/textanalysis/projects/{project}/pipelines/{pipeline}"
+        )
+        return response["payload"]
 
     def _start_pipeline(self, project: str, pipeline: str) -> dict:
         response = self.__request(

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -27,7 +27,7 @@ URL_BASE_ID = "https://localhost:8080/information-discovery"
 URL_BASE_HD = "https://localhost:8080/health-discovery"
 API_BASE = URL_BASE_ID + "/rest/v1"
 TEST_DIRECTORY = os.path.dirname(__file__)
-
+TEST_API_TOKEN = "I-am-a-dummy-API-token"
 
 ## Mock different platforms. The difference between the platforms is in the URL and in the specVersion number.
 
@@ -78,16 +78,16 @@ def client(request, requests_mock):
         headers={"Content-Type": "application/json"},
         json={"payload": {"specVersion": request.param, "buildNumber": ""}, "errorMessages": []},
     )
-    return Client(URL_BASE_ID)
+    return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)
 
 
 # Tests that should work in platform version 5
 @pytest.fixture
 def client_version_5(requests_mock_id5):
-    return Client(URL_BASE_ID)
+    return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)
 
 
 # Tests that should work in platform version 6
 @pytest.fixture()
 def client_version_6(requests_mock_id6):
-    return Client(URL_BASE_ID)
+    return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -216,11 +216,6 @@ def test_create_pipeline_schema_version_two(client, requests_mock):
     assert new_pipeline is None
 
 
-def test_delete_pipeline(client):
-    with pytest.raises(OperationNotSupported):
-        client._delete_pipeline("LoadTesting", "discharge")
-
-
 def test_start_pipeline(client, requests_mock):
     requests_mock.put(
         f"{API_BASE}/textanalysis/projects/LoadTesting/pipelines/discharge/start",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,7 +29,7 @@ from averbis.core import (
 )
 from tests.fixtures import *
 
-TEST_API_TOKEN = "I-am-a-dummy-API-token"
+
 TEST_DIRECTORY = os.path.dirname(__file__)
 
 logging.basicConfig(level=logging.INFO)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -22,7 +22,7 @@ import time
 from pathlib import Path
 
 from averbis import Project, Pipeline
-from averbis.core import OperationTimeoutError
+from averbis.core import OperationTimeoutError, OperationNotSupported
 from tests.fixtures import *
 
 logging.basicConfig(level=logging.INFO)
@@ -242,3 +242,19 @@ def test_analyse_texts_(client, pipeline_analyse_text_mock):
 
     assert sources[0].endswith("tests/resources/texts/text1.txt")
     assert sources[1].endswith("tests/resources/texts/text2.txt")
+
+
+def test_delete_pipeline_v5(client_version_5):
+    pipeline = Pipeline(Project(client_version_5, "LoadTesting"), "discharge")
+    with pytest.raises(OperationNotSupported):
+        pipeline.delete()
+
+
+def test_delete_pipeline_v6(client_version_6, requests_mock):
+    pipeline = Pipeline(Project(client_version_6, "LoadTesting"), "discharge")
+    requests_mock.delete(
+        f"{URL_BASE_ID}/rest/experimental/textanalysis/projects/LoadTesting/pipelines/discharge",
+        headers={"Content-Type": "application/json"},
+        json={"payload": None, "errorMessages": []},
+    )
+    pipeline.delete()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -258,3 +258,46 @@ def test_delete_pipeline_v6(client_version_6, requests_mock):
         json={"payload": None, "errorMessages": []},
     )
     pipeline.delete()
+
+
+def test_export_text_analysis_export_v5(client_version_5):
+    project = Project(client_version_5, "LoadTesting")
+    with pytest.raises(OperationNotSupported):
+        project.export_text_analysis(document_sources="my_document_sources", process="my_process")
+
+
+def test_export_text_analysis_export_v6(client_version_6, requests_mock):
+    project = Project(client_version_6, "LoadTesting")
+    requests_mock.get(
+        f"{URL_BASE_ID}/rest/experimental/textanalysis/projects/LoadTesting/documentSources/my_document_sources/processes/my_process/export",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "projectName": "LoadTesting",
+                "documentSourceName": "my_document_sources",
+                "textAnalysisResultSetName": "my_process",
+                "pipelineName": "discharge",
+                "textAnalysisResultDtos": [
+                    {
+                        "documentName": "abcdef.txt",
+                        "annotationDtos": [
+                            {
+                                "begin": 0,
+                                "end": 12,
+                                "type": "uima.tcas.DocumentAnnotation",
+                                "coveredText": "Hello World",
+                                "id": 66753,
+                            }
+                        ]
+                        # truncated #
+                    }
+                    # truncated #
+                ],
+            },
+            "errorMessages": [],
+        },
+    )
+    export = project.export_text_analysis(
+        document_sources="my_document_sources", process="my_process"
+    )
+    assert export["documentSourceName"] == "my_document_sources"


### PR DESCRIPTION
Added two new experimental endpoints:

1. For deleting an existing pipeline
2. For exporting a text analysis process

Both endpoints are only available in the platform version 6 onwards.