### PR TITLE
Feature/robust URLs

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -952,12 +952,15 @@ class Client:
 
         kwargs["verify"] = self._verify_ssl
 
-        url = f"{self._url}/rest/{endpoint.lstrip('/')}"
+        url = self.__build_url(endpoint)
         raw_response = requests.request(method, url, **kwargs)
         self.__logger.debug(
             "Response for %s %s: %s -- %s", method, url, raw_response, raw_response.content
         )
         return raw_response
+
+    def __build_url(self, endpoint):
+        return f"{self._url.rstrip('/')}/rest/{endpoint.lstrip('/')}"
 
     def __request(self, method: str, endpoint: str, **kwargs) -> dict:
         raw_response = self._run_request(method, endpoint, **kwargs)

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -952,14 +952,14 @@ class Client:
 
         kwargs["verify"] = self._verify_ssl
 
-        url = self.__build_url(endpoint)
+        url = self._build_url(endpoint)
         raw_response = requests.request(method, url, **kwargs)
         self.__logger.debug(
             "Response for %s %s: %s -- %s", method, url, raw_response, raw_response.content
         )
         return raw_response
 
-    def __build_url(self, endpoint):
+    def _build_url(self, endpoint):
         return f"{self._url.rstrip('/')}/rest/{endpoint.lstrip('/')}"
 
     def __request(self, method: str, endpoint: str, **kwargs) -> dict:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,6 +44,12 @@ def test_default_headers(client):
     assert TEST_API_TOKEN == headers["api-token"]
 
 
+def test_build_url(client):
+    client._url = 'http://some-machine/health-discovery/'
+    print(client.__build_url('v1/some-endpoint/'))
+    # assert test_client.__build_url('v1/some-endpoint/') ==
+
+
 def test_default_headers_with_override(client):
     headers = client._default_headers({"Content-Type": "text/plain"})
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,8 +46,7 @@ def test_default_headers(client):
 
 def test_build_url(client):
     client._url = 'http://some-machine/health-discovery/'
-    print(client.__build_url('v1/some-endpoint/'))
-    # assert test_client.__build_url('v1/some-endpoint/') ==
+    assert client._build_url('v1/some-endpoint/') == 'http://some-machine/health-discovery/rest/v1/some-endpoint/'
 
 
 def test_default_headers_with_override(client):


### PR DESCRIPTION
The Client is not robust against a trailing slash in the URL. The double slash leads to a 500 exception (which of cause should not happen by the platform but still this error can be prevented).
