### PR TITLE
Issue #63: Use results type system instead of obtaining one from the pipeline

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -212,8 +212,9 @@ def test_export_text_analysis_to_cas_v6(client_version_6, requests_mock):
     process = Process(project, "my-process", collection.name, pipeline.name)
 
     requests_mock.get(
-        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/pipelines/{pipeline.name}/exportTypesystem",
-        headers={"Content-Type": "text/xml"},
+        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
+        f"/documents/{document_id}/processes/{process.name}/exportTypesystem",
+        headers={"Content-Type": "application/xml"},
         text=empty_typesystem,
     )
 


### PR DESCRIPTION
- Use the new endpoint for obtaining a type system specifically for one result
- Rename internal some method to align with endpoint names