### PR TITLE
Refactoring/54 move process from project to document level

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -113,6 +113,12 @@ class Pipeline:
         self.pipeline_state_change_timeout = self.pipeline_state_poll_interval * 10
         self.cached_type_system = None
 
+    def __repr__(self):
+        """
+        A nicer string representation of the Pipeline object.
+        """
+        return f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}")'
+
     def wait_for_pipeline_to_leave_transient_state(self) -> str:
         pipeline_info = self.get_info()
         total_time_slept = 0
@@ -373,6 +379,12 @@ class Terminology:
         self.project = project
         self.name = name
 
+    def __repr__(self):
+        """
+        A nicer string representation of the Terminology object.
+        """
+        return f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}")'
+
     def start_export(self, terminology_format: str = TERMINOLOGY_EXPORTER_OBO_1_4) -> None:
         """
         Trigger the export of the terminology.
@@ -475,6 +487,14 @@ class Process:
         self.document_source_name = document_source_name
         self.pipeline_name = pipeline_name
 
+    def __repr__(self):
+        """
+        A nicer string representation of the Process object.
+        """
+        return f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}",' \
+               f' pipeline_name="{self.pipeline_name}", document_source_name="{self.document_source_name}")'
+
+
     class ProcessState:
         def __init__(
             self,
@@ -575,6 +595,12 @@ class DocumentCollection:
         self.project = project
         self.name = name
 
+    def __repr__(self):
+        """
+        A nicer string representation of the DocumentCollection object.
+        """
+        return f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}")'
+
     def get_number_of_documents(self) -> int:
         """
         Returns the number of documents in that collection.
@@ -637,6 +663,12 @@ class Pear:
         self.project = project
         self.identifier = identifier
 
+    def __repr__(self):
+        """
+        A nicer string representation of the Pear object.
+        """
+        return f'{self.__class__.__name__}(identifier="{self.identifier}", project="{self.project.name}")'
+
     @experimental_api
     def delete(self):
         """
@@ -665,6 +697,12 @@ class Project:
         self.client = client
         self.name = name
         self.__cached_pipelines: dict = {}
+
+    def __repr__(self):
+        """
+        A nicer string representation of the Project object.
+        """
+        return f'{self.__class__.__name__}(name="{self.name}")'
 
     def get_pipeline(self, name: str) -> Pipeline:
         """
@@ -922,6 +960,13 @@ class Client:
 
         self._build_info: dict = {}
         self._spec_version: str = ""
+
+    def __repr__(self):
+        """
+        A nicer string representation of the Client object.
+        """
+        return f'{self.__class__.__name__}({self._url})'
+
 
     def _exists_profile(self, profile: str):
         return (

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -113,9 +113,6 @@ class Pipeline:
         self.cached_type_system = None
 
     def __repr__(self):
-        """
-        A nicer string representation of the Pipeline object.
-        """
         return f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}")'
 
     def wait_for_pipeline_to_leave_transient_state(self) -> str:
@@ -379,9 +376,6 @@ class Terminology:
         self.name = name
 
     def __repr__(self):
-        """
-        A nicer string representation of the Terminology object.
-        """
         return f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}")'
 
     def start_export(self, terminology_format: str = TERMINOLOGY_EXPORTER_OBO_1_4) -> None:
@@ -487,9 +481,6 @@ class Process:
         self.pipeline_name = pipeline_name
 
     def __repr__(self):
-        """
-        A nicer string representation of the Process object.
-        """
         return (
             f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}",'
             f' pipeline_name="{self.pipeline_name}", document_source_name="{self.document_source_name}")'
@@ -595,14 +586,7 @@ class DocumentCollection:
         self.project = project
         self.name = name
 
-    @property
-    def client(self):
-        return self.project.client
-
     def __repr__(self):
-        """
-        A nicer string representation of the DocumentCollection object.
-        """
         return f'{self.__class__.__name__}(name="{self.name}", project="{self.project.name}")'
 
     def get_number_of_documents(self) -> int:
@@ -610,7 +594,7 @@ class DocumentCollection:
         Returns the number of documents in that collection.
         """
         # noinspection PyProtectedMember
-        return self.client._get_document_collection(self.project.name, self.name)[
+        return self.project.client._get_document_collection(self.project.name, self.name)[
             "numberOfDocuments"
         ]
 
@@ -623,7 +607,7 @@ class DocumentCollection:
         :return: The process
         """
         # noinspection PyProtectedMember
-        return self.client._get_process(self, process_name)
+        return self.project.client._get_process(self, process_name)
 
     @experimental_api
     def create_and_run_process(
@@ -638,7 +622,7 @@ class DocumentCollection:
         :return: The created process
         """
         # noinspection PyProtectedMember
-        self.client._create_and_run_process(self, process_name, pipeline)
+        self.project.client._create_and_run_process(self, process_name, pipeline)
 
         return self.get_process(process_name)
 
@@ -696,9 +680,6 @@ class Pear:
         self.identifier = identifier
 
     def __repr__(self):
-        """
-        A nicer string representation of the Pear object.
-        """
         return f'{self.__class__.__name__}(identifier="{self.identifier}", project="{self.project.name}")'
 
     @experimental_api
@@ -731,9 +712,6 @@ class Project:
         self.__cached_pipelines: dict = {}
 
     def __repr__(self):
-        """
-        A nicer string representation of the Project object.
-        """
         return f'{self.__class__.__name__}(name="{self.name}")'
 
     def get_pipeline(self, name: str) -> Pipeline:
@@ -963,9 +941,6 @@ class Client:
         self._spec_version: str = ""
 
     def __repr__(self):
-        """
-        A nicer string representation of the Client object.
-        """
         return f"{self.__class__.__name__}({self._url})"
 
     def _exists_profile(self, profile: str):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -143,7 +143,7 @@ def test_export_text_analysis_export_v6(client_version_6, requests_mock):
         },
     )
 
-    process = project.get_process(process_name, collection)
+    process = collection.get_process(process_name)
 
     requests_mock.get(
         f"{API_BASE}/textanalysis/projects/{project.name}/"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -129,8 +129,9 @@ def test_create_and_run_process(client_version_6, requests_mock):
         },
     )
 
-    actual_process = project.create_and_run_process(
-        process_name, document_source_name, pipeline_name
+    collection = project.get_document_collection(document_source_name)
+    actual_process = collection.create_and_run_process(
+        process_name=process_name, pipeline=pipeline_name
     )
 
     expected_process = Process(project, process_name, document_source_name, pipeline_name)
@@ -161,7 +162,7 @@ def test_get_process(client_version_6, requests_mock):
         headers={"Content-Type": "application/json"},
         json={"payload": payload, "errorMessages": []},
     )
-    actual = project.get_process(process_name, document_source_name)
+    actual = project.get_document_collection(document_source_name).get_process(process_name)
     assert_process_equal(expected_process, actual)
 
 


### PR DESCRIPTION
- Processes are now tightly coupled to DocumentCollections
- Methods to handle Processes (get_process, create_and_run_process) have been moved from Project to DocumentCollection. 
   -   The only method on project level is project.list_processes() which lists all processes over all collections
- This avoids the passing of duplicate parameters and follows the logic of the API endpoint urls which should simplify it for the user
- (Another refactoring): Added String representation of our classes