### PR TITLE
Issue #62: Allow setting timeout on Client level and for selected endpoints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,23 +6,9 @@ API Reference
 .. automodule:: averbis
     :members:
     :undoc-members:
+    :exclude-members: Client
 
-.. autoclass:: averbis.platform.Client
+.. autoclass:: averbis.Client
    :members:
    :inherited-members:
-   :exclude-members: __init__
-
-.. autoclass:: averbis.platform.Project
-   :members:
-   :inherited-members:
-   :exclude-members: __init__
-
-.. autoclass:: averbis.platform.Pipeline
-   :members:
-   :inherited-members:
-   :exclude-members: __init__
-
-.. autoclass:: averbis.platform.Terminology
-   :members:
-   :inherited-members:
-   :exclude-members: __init__
+   :special-members: __init__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'averbis-python-api'
-copyright = '2020, Averbis GmbH'
+copyright = '2021, Averbis GmbH'
 author = 'Averbis GmbH'
 
 # The short X.Y version


### PR DESCRIPTION
* New timeout parameter and Client level and for some selected endpoints: Specifying the timeout for a selected endpoint prevails over the Client level timeout
* No tests were added; tested timeout parameter manually with a real Heath Discovery instance
* Added documentation for Client constructor, fixed sphinx config (removed specification for classes that do not exist anymore, `__init__` is documented only for Client)
* Fixed copyright year
