### PR TITLE
#89 - Upgrade to DKPro Cassis 0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ REQUIRES_PYTHON = ">=3.6.0"
 install_requires = [
     "requests",
     "types-requests",
-    "dkpro-cassis"
+    "dkpro-cassis>=0.6.0"
 ]
 
 test_dependencies = [


### PR DESCRIPTION
- Set minimum cassis version to 0.6.0