### PR TITLE
Issue #98: Adding `page` and `page_size` parameter to export_text_analysis

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -764,18 +764,19 @@ class Process:
         return self.project.client._get_process_state(self.project, self)
 
     def export_text_analysis(
-        self, annotation_types: str = None, page: int = None, page_size: int = None
+        self, annotation_types: str = None, page: int = None, page_size: int = 100
     ) -> dict:
         """
         Exports a given text analysis process as a json.
 
         The parameter `page` and `page_size` can be used to only export a subset of all results.
-        For instance, setting page=1 and page_size=10 will export document 1-10 of the text analysis result.
-        Setting page=2 and page_size=30 will export document 31-60 of the text analysis result.
+        For instance, setting `page=1` and `page_size=10` will export documents 1-10 of the text analysis result.
+        Setting `page=2` and `page_size=30` will export document 31-60 of the text analysis result.
+        Documents are currently sorted by their internal ID and not by the filename.
 
         :param annotation_types: Optional parameter indicating which types should be returned. Supports wildcard expressions, e.g. "de.averbis.types.*" returns all types with prefix "de.averbis.types"
-        :param page: Optional parameter indicating which batch of pages should be export. Only works in combination with `page_size`.
-        :param page_size: Optional parameter defining how many documents are exported at once. Only works in combination with parameter `page`.
+        :param page: Optional parameter indicating which batch of pages should be export.
+        :param page_size: Optional parameter defining how many documents are exported at once (default=100). Only restricts the number of documents to that number if the parameter `page` is given.
 
         :return: The raw payload of the server response. Future versions of this library may return a better-suited
          representation.
@@ -785,10 +786,9 @@ class Process:
                 "Text analysis export is not supported for platform version 5.x, it is only supported from 6.x onwards."
             )
 
-        if (page is not None and page_size is None) or (page is not None and page_size is None):
-            raise ValueError(
-                f"The argument page={page} and page_size={page_size} need either both be present or absent. But one is absent. "
-            )
+        if page is None:
+            # We need to set page_size to None because the Client expects both parameters or neither of them.
+            page_size = None
 
         # noinspection PyProtectedMember
         return self.project.client._export_text_analysis(

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -764,7 +764,10 @@ class Process:
         return self.project.client._get_process_state(self.project, self)
 
     def export_text_analysis(
-        self, annotation_types: str = None, page: int = None, page_size: int = 100
+        self,
+        annotation_types: str = None,
+        page: Union[int, None] = None,
+        page_size: Union[int, None] = 100,
     ) -> dict:
         """
         Exports a given text analysis process as a json.
@@ -2038,8 +2041,8 @@ class Client:
         document_source: str,
         process: str,
         annotation_types: str = None,
-        page: int = None,
-        page_size: int = None,
+        page: Union[int, None] = None,
+        page_size: Union[int, None] = None,
     ):
         """
         Use Process.export_text_analysis() instead.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -30,6 +30,7 @@ API_EXPERIMENTAL = URL_BASE_ID + "/rest/experimental"
 TEST_DIRECTORY = os.path.dirname(__file__)
 TEST_API_TOKEN = "I-am-a-dummy-API-token"
 PROJECT_NAME = "test-project"
+COLLECTION_NAME = "my-collection"
 
 ## Mock different platforms. The difference between the platforms is in the URL and in the specVersion number.
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -266,6 +266,10 @@ def test_export_text_analysis_with_page_and_pagsize(client_version_6, requests_m
     assert len(export2["textAnalysisResultDtos"]) == 4
     assert export2["textAnalysisResultDtos"][-1]["documentName"] == "Document (8).txt"
 
+    export3 = process.export_text_analysis(page=2)
+    assert len(export3["textAnalysisResultDtos"]) == 100
+    assert export3["textAnalysisResultDtos"][-1]["documentName"] == "Document (200).txt"
+
 
 def test_export_text_analysis_to_cas_v5(client_version_5):
     document_id = "document0001"

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -145,7 +145,7 @@ def test_export_text_analysis_export_v5(client_version_5):
         project=Project(client_version_5, PROJECT_NAME),
         name="my-process",
         pipeline_name="my-pipeline",
-        document_source_name="my-collection",
+        document_source_name=COLLECTION_NAME,
     )
 
     with pytest.raises(OperationNotSupported):
@@ -154,7 +154,7 @@ def test_export_text_analysis_export_v5(client_version_5):
 
 def test_export_text_analysis_export_v6(client_version_6, requests_mock):
     project = Project(client_version_6, PROJECT_NAME)
-    collection = project.get_document_collection("my-collection")
+    collection = project.get_document_collection(COLLECTION_NAME)
     process_name = "my-process"
 
     requests_mock.get(
@@ -213,13 +213,67 @@ def test_export_text_analysis_export_v6(client_version_6, requests_mock):
     assert export["documentSourceName"] == collection.name
 
 
+def test_export_text_analysis_with_page_and_pagsize(client_version_6, requests_mock):
+    project = Project(client_version_6, PROJECT_NAME)
+    collection = project.get_document_collection(COLLECTION_NAME)
+    process_name = "my-process"
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/"
+        f"documentSources/{collection.name}/processes/{process_name}",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "processName": process_name,
+                "pipelineName": "my-pipeline",
+                "documentSourceName": collection.name,
+                "state": "IDLE",
+                # Truncated
+            },
+            "errorMessages": [],
+        },
+    )
+    process = collection.get_process(process_name)
+
+    def callback(request, _content):
+        page_size = int(request.qs["pageSize"][0])
+        page = int(request.qs["page"][0])
+        return_payload = [
+            {"documentName": f"Document ({page_size*(page-1)+k}).txt", "annotationDtos": []}
+            for k in range(1, page_size + 1)
+        ]
+        return {
+            "payload": {
+                "textAnalysisResultDtos": return_payload,
+                "projectName": project.name,
+                # Truncated
+            },
+            "errorMessages": [],
+        }
+
+    requests_mock.get(
+        f"{API_BASE}/textanalysis/projects/{project.name}/"
+        f"documentSources/{process.document_source_name}/processes/{process.name}/export",
+        headers={"Content-Type": "application/json"},
+        json=callback,
+    )
+
+    export1 = process.export_text_analysis(page_size=4, page=1)
+    assert len(export1["textAnalysisResultDtos"]) == 4
+    assert export1["textAnalysisResultDtos"][0]["documentName"] == "Document (1).txt"
+
+    export2 = process.export_text_analysis(page_size=4, page=2)
+    assert len(export2["textAnalysisResultDtos"]) == 4
+    assert export2["textAnalysisResultDtos"][-1]["documentName"] == "Document (8).txt"
+
+
 def test_export_text_analysis_to_cas_v5(client_version_5):
     document_id = "document0001"
     process = Process(
         project=Project(client_version_5, PROJECT_NAME),
         name="my-process",
         pipeline_name="my-pipeline",
-        document_source_name="my-collection",
+        document_source_name=COLLECTION_NAME,
     )
 
     with pytest.raises(OperationNotSupported):
@@ -228,7 +282,7 @@ def test_export_text_analysis_to_cas_v5(client_version_5):
 
 def test_export_text_analysis_to_cas_v6(client_version_6, requests_mock):
     project = client_version_6.get_project(PROJECT_NAME)
-    collection = project.get_document_collection("my-collection")
+    collection = project.get_document_collection(COLLECTION_NAME)
     document_id = "document0001"
     expected_xmi = """<?xml version="1.0" encoding="UTF-8"?>
         <xmi:XMI xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" 


### PR DESCRIPTION
- adding page and page_size as parameters to export_text_analysis
- some documentation
- added unit test (but also tested it in live product, see comment: https://github.com/averbis/averbis-python-api/issues/98#issuecomment-988057715)