### PR TITLE
Issue #133: Support type filter for exporting as CAS

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -927,12 +927,17 @@ class Process:
     def export_text_analysis_to_cas(
             self,
             document_name: str,
-            type_system: Optional[TypeSystem] = None
+            type_system: Optional[TypeSystem] = None,
+            annotation_types: Optional[str] = None
     ) -> Cas:
         """
         HIGHLY EXPERIMENTAL API - may soon change or disappear.
 
         Returns an analysis as a UIMA CAS.
+        :param document_name: the name of the document whose text analysis result will be exported
+        :param type_system: Optional parameter for the typesystem that the exported CAS will be set up with.
+        :param annotation_types: Optional parameter indicating which types should be returned. Supports wildcard expressions, e.g. "de.averbis.types.*" returns all types with prefix "de.averbis.types"
+
         """
         if self.project.client.get_build_info()["specVersion"].startswith("5."):
             raise OperationNotSupported(
@@ -964,6 +969,7 @@ class Process:
                 document_name,
                 document_identifier,
                 self,
+                annotation_types
             ),
             typesystem=cas_type_system,
         )
@@ -2386,6 +2392,7 @@ class Client:
         document_name: str,
         document_id: str,
         process: Union[Process, str],
+        annotation_types: str
     ) -> str:
         """
         HIGHLY EXPERIMENTAL API - may soon change or disappear.
@@ -2400,6 +2407,9 @@ class Client:
             )
 
         process_name = self.__process_name(process)
+        request_params = {"documentName": document_name}
+        if annotation_types is not None:
+            request_params["annotationTypes"] = annotation_types
 
         try:
             return str(
@@ -2410,7 +2420,7 @@ class Client:
                     headers={
                         HEADER_ACCEPT: MEDIA_TYPE_APPLICATION_XMI,
                     },
-                    params={"documentName": document_name},
+                    params=request_params,
                 ),
                 ENCODING_UTF_8,
             )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -85,7 +85,17 @@ def requests_mock_id6_11(requests_mock):
     requests_mock.get(
         f"{URL_BASE_ID + '/rest/v1'}/buildInfo",
         headers={"Content-Type": "application/json"},
-        json={"payload": {"specVersion": "6.11.0", "buildNumber": ""}, "errorMessages": []},
+        json={"payload": {"specVersion": "6.11.0", "buildNumber": ""}, "errorMessages": []}
+    )
+
+
+@pytest.fixture()
+def requests_mock_platform6_48_0(requests_mock):
+    requests_mock.get(
+        f"{URL_BASE_ID + '/rest/v1'}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "6.17.0", "buildNumber": "", "platformVersion": "6.48.0"},
+              "errorMessages": []}
     )
 
 
@@ -123,4 +133,10 @@ def client_version_6_7(requests_mock_id6_7):
 # Tests that should work in version 6.11
 @pytest.fixture()
 def client_version_6_11(requests_mock_id6_11):
+    return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)
+
+
+# Tests that require a platform version 6.49.1
+@pytest.fixture()
+def client_version_6_17_0_platform_6_48_0(requests_mock_platform6_48_0):
     return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -431,6 +431,53 @@ def test_export_text_analysis_to_cas_v6_7_provide_typesystem(client_version_6_7,
     assert cas.sofa_string == "Test"
 
 
+def test_export_text_analysis_to_cas_annotation_types_not_supported(
+        client_version_6_17_0_platform_6_48_0,
+        requests_mock):
+    project = client_version_6_17_0_platform_6_48_0.get_project(PROJECT_NAME)
+    collection = project.get_document_collection(COLLECTION_NAME)
+    document_id = "document0001"
+    document_name = "document.txt"
+    expected_xmi = """<?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" 
+        xmlns:cas="http:///uima/cas.ecore"
+                 xmi:version="2.0">
+            <cas:NULL xmi:id="0"/>
+            <tcas:DocumentAnnotation xmi:id="2" sofa="1" begin="0" end="4" language="x-unspecified"/>
+            <cas:Sofa xmi:id="1" sofaNum="1" sofaID="_InitialView" mimeType="text/plain"
+                      sofaString="Test"/>
+            <cas:View sofa="1" members="2"/>
+        </xmi:XMI>
+        """
+    empty_typesystem = '<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier"/>'
+    cas_typesystem = load_typesystem(empty_typesystem)
+    pipeline = Pipeline(project, "my-pipeline")
+    process = Process(project, "my-process", collection.name, pipeline.name)
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/projects/{project.name}/documentCollections/{collection.name}/documents",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": [{"documentIdentifier": document_id, "documentName": document_name}],
+            "errorMessages": [],
+        },
+    )
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
+        f"/processes/{process.name}/textAnalysisResult",
+        headers={"Content-Type": "application/vnd.uima.cas+xmi"},
+        text=expected_xmi,
+    )
+
+    cas = process.export_text_analysis_to_cas(
+        document_name,
+        type_system=cas_typesystem,
+        annotation_types="de.averbis.types.health.Diagnosis")
+
+    assert cas.sofa_string == "Test"
+
+
 def test_add_text_analysis_result_cas(client_version_6, requests_mock):
     project = client_version_6.get_project(PROJECT_NAME)
     collection = project.get_document_collection(COLLECTION_NAME)


### PR DESCRIPTION
**What's in the PR?**

Support optional parameter in `export_text_analysis_to_cas`to limit the export to specific annotation types. 

**How to test manually**

- Export the textanalysis result of a specific collection, process and document as CAS with `export_text_analysis_to_cas` and specifiy the annotation type(s) you would like to export.
- Check that only those types were exported.
- Check that export without this parameter still works.