### PR TITLE
Issue #139: Normalize URL in Client

### DIFF
--- a/averbis/__init__.py
+++ b/averbis/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Averbis GmbH.
+# Copyright (c) 2023 Averbis GmbH.
 #
 # This file is part of Averbis Python API.
 # See https://www.averbis.com for further info.

--- a/averbis/__version__.py
+++ b/averbis/__version__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Averbis GmbH.
+# Copyright (c) 2023 Averbis GmbH.
 #
 # This file is part of Averbis Python API.
 # See https://www.averbis.com for further info.

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Averbis GmbH.
+# Copyright (c) 2023 Averbis GmbH.
 #
 # This file is part of Averbis Python API.
 # See https://www.averbis.com for further info.
@@ -1583,6 +1583,8 @@ class Client:
                 self._apply_profile("*")
             self._apply_profile(url_or_id)
 
+        self._normalize_url()
+
         if self._api_token is None:
             if username is not None and password is not None:
                 self.regenerate_api_token(username, password)
@@ -1646,6 +1648,10 @@ class Client:
                 return json.load(source)
 
         return {}
+
+    def _normalize_url(self) -> None:
+        if self._url.endswith("#/"):
+            self._url = self._url[:-2]
 
     def set_timeout(self, timeout: float) -> "Client":
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,6 @@
 #
 import logging
 import zipfile
-import tempfile
 from pathlib import Path
 
 from averbis import Pipeline, Project
@@ -43,6 +42,17 @@ def test_default_headers(client):
 
     assert headers["Accept"] == "application/json"
     assert TEST_API_TOKEN == headers["api-token"]
+
+
+def test_normalize_url_remove_angular_extension_in_client(requests_mock):
+    """ Tests if the url extension '#/' is removed when initializing the Client """
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "6.0", "buildNumber": ""}, "errorMessages": []},
+    )
+    client = Client("http://some-machine/health-discovery/#/", api_token=TEST_API_TOKEN)
+    assert client._url == "http://some-machine/health-discovery/"
 
 
 def test_build_url(client):

--- a/tests/test_document_collection.py
+++ b/tests/test_document_collection.py
@@ -21,8 +21,7 @@ from pathlib import Path
 
 from cassis import Cas, TypeSystem
 
-from averbis import DocumentCollection, Process
-from averbis.core import MEDIA_TYPE_APPLICATION_XMI
+from averbis import DocumentCollection
 from tests.fixtures import *
 from tests.utils import *
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from cassis import Cas
 from requests_toolbelt import MultipartDecoder
 
-from averbis import Project, Pipeline, Process
+from averbis import Project, Pipeline
 from averbis.core import (
     OperationTimeoutError,
     OperationNotSupported,


### PR DESCRIPTION
* Removed trailing "#/" in `Client` url
* also removed unneeded imports and updated copyright year