### PR TITLE
Issue #141: Get document typesystem by name instead of id

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -963,9 +963,9 @@ class Process:
             self,
             type_system: TypeSystem,
             document_collection: "DocumentCollection",
-            document_name: str,
-            document_identifier: Optional[str] = None
-    ) -> Tuple[TypeSystem, str]:
+            document_name: str
+    ) -> Tuple[TypeSystem, Optional[str]]:
+        document_identifier = None
         cas_type_system = type_system
         if cas_type_system is None:
             try:

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -968,14 +968,16 @@ class Process:
         document_identifier = None
         cas_type_system = type_system
         if cas_type_system is None:
-            try:
+            build_info = self.project.client.get_build_info()
+            # noinspection PyProtectedMember
+            if "platformVersion" in build_info and self.project.client._is_higher_equal_version(build_info["platformVersion"], 6, 50):
                 # noinspection PyProtectedMember
                 cas_type_system = load_typesystem(
                     self.project.client._export_analysis_result_typesystem(
                         self.project.name, self.document_source_name, document_name, self
                     )
                 )
-            except RequestException as e:
+            else:
                 # noinspection PyProtectedMember
                 document_identifier = document_collection._get_document_identifier(document_name)
                 # noinspection PyProtectedMember
@@ -3140,3 +3142,9 @@ class Client:
         )
         process.name = new_name
         return process
+
+    @staticmethod
+    def _is_higher_equal_version(version: str, compare_major: int, compare_minor: int) -> bool:
+        version_parts = version.split(".")
+        major = int(version_parts[0])
+        return major > compare_major or (major == compare_major and int(version_parts[1]) >= compare_minor)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -89,6 +89,15 @@ def requests_mock_id6_11(requests_mock):
     )
 
 
+@pytest.fixture()
+def requests_mock_platform_6_50(requests_mock):
+    requests_mock.get(
+        f"{URL_BASE_ID + '/rest/v1'}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "6.17.0", "buildNumber": "", "platformVersion": "6.50.0"}, "errorMessages": []},
+    )
+
+
 ## Different clients based on the above platforms
 
 # Tests that should work for all platform versions
@@ -123,4 +132,10 @@ def client_version_6_7(requests_mock_id6_7):
 # Tests that should work in version 6.11
 @pytest.fixture()
 def client_version_6_11(requests_mock_id6_11):
+    return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)
+
+
+# Test that shoould work with product version 6.17 and platform version 6.50
+@pytest.fixture()
+def client_version_6_17_platform_6_50(requests_mock_platform_6_50):
     return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,6 +20,7 @@
 import logging
 import time
 from pathlib import Path
+from typing import Optional
 
 from cassis import Cas
 from requests_toolbelt import MultipartDecoder
@@ -256,7 +257,7 @@ class PipelineEndpointMock:
         self.state_locked = False
 
     def set_state(
-        self, state: str, locked: bool = False, pipeline_state_message: str = None
+        self, state: str, locked: bool = False, pipeline_state_message: Optional[str] = None
     ) -> None:
         self.state = state
         self.requested_state = state

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -286,8 +286,8 @@ def test_export_text_analysis_to_cas_v5(client_version_5):
         process.export_text_analysis_to_cas(document_name)
 
 
-def test_export_text_analysis_to_cas_v6_full_name_support(client_version_6_7, requests_mock):
-    project = client_version_6_7.get_project(PROJECT_NAME)
+def test_export_text_analysis_to_cas_v6_full_name_support(client_version_6_17_platform_6_50, requests_mock):
+    project = client_version_6_17_platform_6_50.get_project(PROJECT_NAME)
     collection = project.get_document_collection(COLLECTION_NAME)
     document_name = "document.txt"
     expected_xmi = """<?xml version="1.0" encoding="UTF-8"?>
@@ -346,14 +346,6 @@ def test_export_text_analysis_to_cas_v6_onlycas_export_by_name_support(client_ve
 
     requests_mock.get(
         f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
-        f"/processes/{process.name}/textAnalysisResultTypeSystem",
-        headers={"Content-Type": "application/xml"},
-        text=empty_typesystem,
-        status_code=405
-    )
-
-    requests_mock.get(
-        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
         f"/documents/{document_id}/processes/{process.name}/exportTextAnalysisResultTypeSystem",
         headers={"Content-Type": "application/xml"},
         text=empty_typesystem
@@ -367,7 +359,6 @@ def test_export_text_analysis_to_cas_v6_onlycas_export_by_name_support(client_ve
             "errorMessages": [],
         },
     )
-
     requests_mock.get(
         f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
         f"/processes/{process.name}/textAnalysisResult",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -286,7 +286,45 @@ def test_export_text_analysis_to_cas_v5(client_version_5):
         process.export_text_analysis_to_cas(document_name)
 
 
-def test_export_text_analysis_to_cas_v6_7(client_version_6_7, requests_mock):
+def test_export_text_analysis_to_cas_v6_full_name_support(client_version_6_7, requests_mock):
+    project = client_version_6_7.get_project(PROJECT_NAME)
+    collection = project.get_document_collection(COLLECTION_NAME)
+    document_name = "document.txt"
+    expected_xmi = """<?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" 
+        xmlns:cas="http:///uima/cas.ecore"
+                 xmi:version="2.0">
+            <cas:NULL xmi:id="0"/>
+            <tcas:DocumentAnnotation xmi:id="2" sofa="1" begin="0" end="4" language="x-unspecified"/>
+            <cas:Sofa xmi:id="1" sofaNum="1" sofaID="_InitialView" mimeType="text/plain"
+                      sofaString="Test"/>
+            <cas:View sofa="1" members="2"/>
+        </xmi:XMI>
+        """
+    empty_typesystem = '<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier"/>'
+    pipeline = Pipeline(project, "my-pipeline")
+    process = Process(project, "my-process", collection.name, pipeline.name)
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
+        f"/processes/{process.name}/textAnalysisResultTypeSystem",
+        headers={"Content-Type": "application/xml"},
+        text=empty_typesystem,
+    )
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
+        f"/processes/{process.name}/textAnalysisResult",
+        headers={"Content-Type": "application/vnd.uima.cas+xmi"},
+        text=expected_xmi,
+    )
+
+    cas = process.export_text_analysis_to_cas(document_name)
+
+    assert cas.sofa_string == "Test"
+
+
+def test_export_text_analysis_to_cas_v6_onlycas_export_by_name_support(client_version_6_7, requests_mock):
     project = client_version_6_7.get_project(PROJECT_NAME)
     collection = project.get_document_collection(COLLECTION_NAME)
     document_id = "document0001"
@@ -308,9 +346,17 @@ def test_export_text_analysis_to_cas_v6_7(client_version_6_7, requests_mock):
 
     requests_mock.get(
         f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
-        f"/documents/{document_id}/processes/{process.name}/exportTextAnalysisResultTypeSystem",
+        f"/processes/{process.name}/textAnalysisResultTypeSystem",
         headers={"Content-Type": "application/xml"},
         text=empty_typesystem,
+        status_code=405
+    )
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
+        f"/documents/{document_id}/processes/{process.name}/exportTextAnalysisResultTypeSystem",
+        headers={"Content-Type": "application/xml"},
+        text=empty_typesystem
     )
 
     requests_mock.get(
@@ -326,7 +372,7 @@ def test_export_text_analysis_to_cas_v6_7(client_version_6_7, requests_mock):
         f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
         f"/processes/{process.name}/textAnalysisResult",
         headers={"Content-Type": "application/vnd.uima.cas+xmi"},
-        text=expected_xmi,
+        text=expected_xmi
     )
 
     cas = process.export_text_analysis_to_cas(document_name)
@@ -334,7 +380,7 @@ def test_export_text_analysis_to_cas_v6_7(client_version_6_7, requests_mock):
     assert cas.sofa_string == "Test"
 
 
-def test_export_text_analysis_to_cas_v6(client_version_6, requests_mock):
+def test_export_text_analysis_to_cas_v6_only_id_support(client_version_6, requests_mock):
     project = client_version_6.get_project(PROJECT_NAME)
     collection = project.get_document_collection(COLLECTION_NAME)
     document_id = "document0001"
@@ -356,9 +402,17 @@ def test_export_text_analysis_to_cas_v6(client_version_6, requests_mock):
 
     requests_mock.get(
         f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
-        f"/documents/{document_id}/processes/{process.name}/exportTextAnalysisResultTypeSystem",
+        f"/processes/{process.name}/textAnalysisResultTypeSystem",
         headers={"Content-Type": "application/xml"},
         text=empty_typesystem,
+        status_code=405
+    )
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
+        f"/documents/{document_id}/processes/{process.name}/exportTextAnalysisResultTypeSystem",
+        headers={"Content-Type": "application/xml"},
+        text=empty_typesystem
     )
 
     requests_mock.get(
@@ -374,6 +428,7 @@ def test_export_text_analysis_to_cas_v6(client_version_6, requests_mock):
         f"{API_EXPERIMENTAL}/textanalysis/projects/{project.name}/documentCollections/{collection.name}"
         f"/processes/{process.name}/textAnalysisResult",
         headers={"Content-Type": "application/vnd.uima.cas+xmi"},
+        text=expected_xmi,
         status_code=405
     )
 


### PR DESCRIPTION
**What's in the MR?**

- get typesystem of a document text analysis result by document name instead of identifier
- still allow getting by document identifier