### PR TITLE
Issue #147: Support for annotation_types parameter in create_process …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ install_requires = [
 test_dependencies = [
     "requests-toolbelt>=0.9.1",
     "pytest>=5.2.1",
-    "pytest-lazy-fixture",
     "codecov",
     "pytest-cov",
     "requests-mock",


### PR DESCRIPTION
…and create_and_run_process

- internally uses `annotationTypesToBeSaved` in `createProcessDto` when calling create_process
- valid from platform version >=8.11 (corresponding to HD>=7.1) onwards.
- tested against a local health discovery instance with version 7.1

unrelated: Fixed project setup that was broken with pytest>=8 due to conflict with obsolete module pytest-lazy-fixtures