### PR TITLE
Issue #159: Support for Python 3.12+ & Drop Support for Python 3.6 & Python 3.7

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.x, 3.11]
+        python-version: [3.8, 3.9, 3.10.x, 3.11, 3.12]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.venv
 venv
 __pycache__
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ html:
 	cd docs && make html
 
 license:
-	licenseheaders -t build/apache-2.tmpl -n "Averbis Python API" -y "2021" -o "Averbis GmbH" -u "https://www.averbis.com" -x ".*" "venv/*"
+	licenseheaders -t build/apache-2.tmpl -n "Averbis Python API" -y "2024" -o "Averbis GmbH" -u "https://www.averbis.com" -x ".*" "venv/*"

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Averbis GmbH.
+# Copyright (c) 2024 Averbis GmbH.
 #
 # This file is part of Averbis Python API.
 # See https://www.averbis.com for further info.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Averbis GmbH.
+# Copyright (c) 2024 Averbis GmbH.
 #
 # This file is part of Averbis Python API.
 # See https://www.averbis.com for further info.
@@ -23,16 +23,14 @@
 
 import io
 import os
-import sys
-from shutil import rmtree
 
-from setuptools import setup, Command, find_packages
+from setuptools import find_packages, setup
 
 # Package meta-data.
 NAME = "averbis-python-api"
 DESCRIPTION = "Averbis REST API client for Python."
 AUTHOR = "Averbis GmbH"
-REQUIRES_PYTHON = ">=3.6.0"
+REQUIRES_PYTHON = ">=3.8.0"
 
 install_requires = [
     "requests",
@@ -121,12 +119,11 @@ setup(
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "License :: OSI Approved :: Apache Software License"
+        "Programming Language :: Python :: 3.12",
+        "License :: OSI Approved :: Apache Software License",
     ],
 )


### PR DESCRIPTION
- Adjusted Github workflow to test with python 3.12 & drop tests for Python 3.6, Python 3.7
- Increased minimum Python requirements to 3.8
- Fixed some header & unused imports in setup.py