### PR TITLE
Issue #158: Add support for document deletion endpoint

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -1242,6 +1242,13 @@ class DocumentCollection:
         # noinspection PyProtectedMember
         return self.project.client._list_documents(self.project.name, self.name)
 
+    def delete_document(self, document_name: str) -> dict:
+        """
+        Delete the document identified by name from this docuemnt collection
+        """
+        # noinspection PyProtectedMember
+        return self.project.client._delete_document(self.project.name, self.name, document_name)
+
     @experimental_api
     def list_processes(self) -> List[Process]:
         """
@@ -2857,6 +2864,17 @@ class Client:
             document_collection = project.get_document_collection(item["documentSourceName"])
             processes.append(document_collection.get_process(item["processName"]))
         return processes
+
+    def _delete_document(self, project_name: str, document_collection_name: str, document_name: str) -> dict:
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.20":
+            raise OperationNotSupported(
+                f"The method 'delete_documents' is only supported for platform versions >= 8.20.0 (available from Health Discovery version 7.5.0), but current platform is {build_version['platformVersion']}.")
+
+        response = self.__request_with_json_response(
+            "delete", f"/v1/projects/{project_name}/documentCollections/{document_collection_name}/documents/{document_name}"
+        )
+        return response["payload"]
 
     @experimental_api
     def _create_and_run_process(

--- a/tests/test_document_collection.py
+++ b/tests/test_document_collection.py
@@ -252,6 +252,20 @@ def test_get_process(client_version_6, requests_mock):
 
 def test_delete_document(document_collection, requests_mock):
     document_name = "test.txt"
+
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.5.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.20.0"
+            },
+            "errorMessages": []
+        },
+    )
+
     requests_mock.delete(
         f"{API_BASE}/projects/{PROJECT_NAME}/"
         f"documentCollections/{document_collection.name}/documents/{document_name}",

--- a/tests/test_document_collection.py
+++ b/tests/test_document_collection.py
@@ -248,3 +248,17 @@ def test_get_process(client_version_6, requests_mock):
     )
     actual = project.get_document_collection(document_source_name).get_process(process_name)
     assert_process_equal(expected_process, actual)
+
+
+def test_delete_document(document_collection, requests_mock):
+    document_name = "test.txt"
+    requests_mock.delete(
+        f"{API_BASE}/projects/{PROJECT_NAME}/"
+        f"documentCollections/{document_collection.name}/documents/{document_name}",
+        headers={"Content-Type": "application/json"},
+        json={"payload": None, "errorMessages": []},
+    )
+
+    actual_results = document_collection.delete_document(document_name)
+
+    assert actual_results is None


### PR DESCRIPTION
**What's in the PR?**

Added support for document deletion.

**How to test manually?**

- Run code similar to:
`document_collection.delete_document("test.txt")`
- Check that document was deleted with `document_collection.list_documents()`
