### PR TITLE
Issue #161: Add endpoint for uploading license file

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -1722,6 +1722,21 @@ class Client:
     def __repr__(self):
         return f"{self.__class__.__name__}({self._url})"
 
+    def upload_license(self, license_path: Path) -> dict:
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.21":
+            raise OperationNotSupported(f"The method 'upload_license' is only supported for platform versions >= 8.21.0 (available from Health Discovery version 7.5.0), but current platform is {build_version['platformVersion']}.")
+        with license_path.open("r", encoding=ENCODING_UTF_8) as license_file:
+            license_content = license_file.read()
+            data: IO = BytesIO(license_content.encode(ENCODING_UTF_8))
+            files = {"licenseFile": (license_path.name, data, MEDIA_TYPE_TEXT_PLAIN)}
+            response = self.__request_with_json_response(
+                'put',
+                f"/v1/license",
+                files=files,
+            )
+            return response['payload']
+
     def _exists_profile(self, profile: str):
         return (
             self._settings

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -83,6 +83,36 @@ def test_change_password(client, requests_mock):
     client.change_password("admin", "admin", "admin")
 
 
+def test_upload_license(client, requests_mock):
+    payload = {
+        "valid": True,
+        "expirationDateInMillis": 1753962034965,
+        "expirationDate": "Thu Jul 31 13:40:34 CEST 2025"
+    }
+
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.5.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.21.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.put(
+        f"{API_BASE}/license",
+        headers={"Content-Type": "multi-part/form-data"},
+        json={"payload": payload, "errorMessages": []},
+    )
+    license_path = Path(TEST_DIRECTORY) / "resources" / "texts" / "text1.txt"
+    license_info = client.upload_license(license_path)
+    assert license_info == payload
+
+
 def test_generate_api_token(client, requests_mock):
     requests_mock.post(
         f"{API_BASE}/users/admin/apitoken",


### PR DESCRIPTION
**What's in the PR?**

Added support for license upload.

**How to test manually?**

Test uploading license with:
```
client = Client('url', username='name', password='password')
license_path = Path("my_license.lic")

client.upload_license(license_path)
```

