### PR TITLE
Issue #164: Support new resource API

### DIFF
--- a/averbis/__init__.py
+++ b/averbis/__init__.py
@@ -18,7 +18,7 @@
 #
 #
 from .core import Client, Project, Pipeline, Result, Terminology, DocumentCollection, Pear, Process, \
-    EvaluationConfiguration
+    EvaluationConfiguration, ResourceContainer
 
 __all__ = [
     "Client",
@@ -30,4 +30,5 @@ __all__ = [
     "DocumentCollection",
     "Pear",
     "Process",
+    "ResourceContainer"
 ]

--- a/averbis/core/__init__.py
+++ b/averbis/core/__init__.py
@@ -23,6 +23,7 @@
 from ._rest_client import (
     OperationNotSupported,
     OperationTimeoutError,
+    ResourceContainer,
     Terminology,
     Client,
     Result,
@@ -56,6 +57,7 @@ from ._rest_client import (
 __all__ = [
     "OperationNotSupported",
     "OperationTimeoutError",
+    "ResourceContainer",
     "Terminology",
     "Client",
     "Result",

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -38,7 +38,6 @@ from pathlib import Path
 import requests
 import mimetypes
 
-from deprecation import deprecated
 from requests import RequestException
 
 ENCODING_UTF_8 = "utf-8"
@@ -102,6 +101,16 @@ def experimental_api(original_function):
         return original_function(*args, **kwargs)
 
     return new_function
+
+
+def deprecated(reason):
+    def decorator_deprecated(original_function):
+        @wraps(original_function)
+        def wrapper_deprecated(*args, **kwargs):
+            logging.warning(f"Deprecation: {reason}")
+            return original_function(*args, **kwargs)
+        return wrapper_deprecated
+    return decorator_deprecated
 
 
 class OperationNotSupported(Exception):

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -38,6 +38,7 @@ from pathlib import Path
 import requests
 import mimetypes
 
+from deprecation import deprecated
 from requests import RequestException
 
 ENCODING_UTF_8 = "utf-8"
@@ -137,6 +138,66 @@ class Result:
 
     def successful(self):
         return self.exception is None
+
+
+class ResourceContainer:
+
+    def __init__(
+            self,
+            client: "Client",
+            name: str,
+            scope: str,
+            base_url: str,
+    ):
+        self.client = client
+        self.name = name
+        self.scope = scope
+        self.base_url = base_url
+
+    @experimental_api
+    def list_resources(self) -> List[str]:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        List paths of resources in the container.
+        """
+        # noinspection PyProtectedMember
+        return self.client._list_container_resources(self.name, self.base_url)
+
+    @experimental_api
+    def export_resources(self, target_path: Union[str, Path]) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Export the whole resource container as a zip file.
+        """
+        # noinspection PyProtectedMember
+        self.client._export_container_resources(target_path, self.name, self.base_url)
+
+    @experimental_api
+    def export_resource(self, target_path: Union[str, Path], resource_path: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Export a specific resource file from within the container at the given resources_path.
+        """
+        # noinspection PyProtectedMember
+        self.client._export_resource(target_path, self.name, self.base_url, resource_path)
+
+    @experimental_api
+    def upsert_resource(self, resource_file_path: Union[str, Path], resource_path: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Insert or update the resource at the given resource_path in the container with the file located at resource_file_path.
+        """
+        # noinspection PyProtectedMember
+        self.client._upsert_resource(resource_file_path, self.name, self.base_url, resource_path)
+
+    @experimental_api
+    def delete_resource(self, resource_path: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Delete the resource located at the given path in the container from the container.
+        """
+        # noinspection PyProtectedMember
+        self.client._delete_resource(self.name, self.base_url, resource_path)
 
 
 class Pipeline:
@@ -247,6 +308,39 @@ class Pipeline:
         """
         # noinspection PyProtectedMember
         return self.project.client._get_pipeline_info(self.project.name, self.name)
+
+    @experimental_api
+    def list_resource_containers(self) -> List[ResourceContainer]:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+
+        List the resource containers for the current pipeline.
+        """
+        pipeline_url = f"/experimental/textanalysis/projects/{self.project.name}/pipelines/{self.name}"
+        # noinspection PyProtectedMember
+        return self.project.client._list_resource_containers(pipeline_url)
+
+    @experimental_api
+    def create_resource_container(self, name: str, resources_zip_path: Optional[Union[Path, str]] = None) -> ResourceContainer:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+
+        Create empty resource container with given name for this pipeline or additionally upload zipped resources.
+        """
+        pipeline_url = f"/experimental/textanalysis/projects/{self.project.name}/pipelines/{self.name}"
+        # noinspection PyProtectedMember
+        return self.project.client._create_resource_container(name, pipeline_url, resources_zip_path)
+
+    @experimental_api
+    def delete_resource_container(self, name: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+
+        Delete the resource container with the given name from this project.
+        """
+        pipeline_url = f"/experimental/textanalysis/projects/{self.project.name}/pipelines/{self.name}"
+        # noinspection PyProtectedMember
+        return self.project.client._delete_resource_container(name, pipeline_url)
 
     @experimental_api
     def delete(self) -> dict:
@@ -632,6 +726,7 @@ class Pipeline:
         return self.cached_type_system
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def list_resources(self) -> List[str]:
         """
         List the resources of the pipeline.
@@ -644,6 +739,7 @@ class Pipeline:
         )["files"]
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def delete_resources(self) -> None:
         """
         Delete the resources of the pipeline.
@@ -654,6 +750,7 @@ class Pipeline:
         )
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def upload_resources(
         self, source: Union[IO, Path, str], path_in_zip: Union[Path, str] = ""
     ) -> List[str]:
@@ -670,6 +767,7 @@ class Pipeline:
         )["files"]
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def download_resources(self, target_zip_path: Union[Path, str]) -> None:
         """
         Download pipeline resources and store in given path.
@@ -1380,7 +1478,38 @@ class Project:
         # noinspection PyProtectedMember
         return self.client._list_annotators(self.name)
 
+    @experimental_api
+    def list_resource_containers(self) -> List[ResourceContainer]:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
 
+        List the resource containers for the current project.
+        """
+        project_url = f"/experimental/textanalysis/projects/{self.name}"
+        # noinspection PyProtectedMember
+        return self.client._list_resource_containers(project_url)
+
+    @experimental_api
+    def create_resource_container(self, name: str, resources_zip_path: Optional[Union[Path, str]] = None) -> ResourceContainer:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+
+        Create empty resource container with given name for this project or additionally upload zipped resources.
+        """
+        project_url = f"/experimental/textanalysis/projects/{self.name}"
+        # noinspection PyProtectedMember
+        return self.client._create_resource_container(name, project_url, resources_zip_path)
+
+    @experimental_api
+    def delete_resource_container(self, name: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+
+        Delete the resource container with the given name from this project.
+        """
+        project_url = f"/experimental/textanalysis/projects/{self.name}"
+        # noinspection PyProtectedMember
+        return self.client._delete_resource_container(name, project_url)
 
     @experimental_api
     def exists_pipeline(self, name: str) -> bool:
@@ -1542,6 +1671,7 @@ class Project:
         return self.client._list_processes(self)
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def list_resources(self) -> List[str]:
         """
         List the resources of the project.
@@ -1552,6 +1682,7 @@ class Project:
         return self.client._list_resources(project_name=self.name)["files"]
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def download_resources(self, target_zip_path: Union[Path, str]) -> None:
         """
         Download Project-level pipeline resources and store in given path.
@@ -1560,6 +1691,7 @@ class Project:
         self.client._download_resources(target_zip_path, project_name=self.name)
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def delete_resources(self) -> None:
         """
         Delete the resources of the project.
@@ -1568,6 +1700,7 @@ class Project:
         self.client._delete_resources(project_name=self.name)
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def upload_resources(
         self, source: Union[IO, Path, str], path_in_zip: Union[Path, str] = ""
     ) -> List[str]:
@@ -2045,6 +2178,193 @@ class Client:
         return Project(self, name)
 
     @experimental_api
+    def delete_resource_container(self, name: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Delete the named global resource container
+        """
+        client_base_url = "/experimental/textanalysis"
+        self._delete_resource_container(name, client_base_url)
+
+    @experimental_api
+    def _delete_resource_container(self, name: str, base_url: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use the respective public delete_resource_container() method.
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        container_url = f"{base_url}/containers/{name}"
+        self.__request_with_json_response("delete", container_url)
+
+    @experimental_api
+    def _delete_resource(self, container_name: str, base_url: str, resource_path: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use ResourceContainer.delete_resource() instead.
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        self.__request_with_json_response("delete", f"{base_url}/{container_name}/resources",
+                                          params={"relativePath": resource_path})
+
+    @experimental_api
+    def list_resource_containers(self) -> List[ResourceContainer]:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        List all global resource containers
+        """
+        client_base_url = "/experimental/textanalysis"
+        return self._list_resource_containers(client_base_url)
+
+    @experimental_api
+    def _list_resource_containers(self, base_url) -> List[ResourceContainer]:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use respective public list_container_resources() instead
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        container_url = f"{base_url}/containers"
+        response = self.__request_with_json_response("get", container_url)
+        if response["errorMessages"]:
+            raise Exception(
+                f"Error while listing resource containers: {response['errorMessages']}"
+            )
+        payload = response["payload"]
+        containers = payload["containers"]
+        return [ResourceContainer(self, container["name"], container["scope"], container_url) for container in
+                containers]
+
+    @experimental_api
+    def create_resource_container(self, name: str, resources_zip_path: Optional[Union[Path, str]] = None) -> ResourceContainer:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Create global empty resource container or additionally upload provided resources to the new container.
+        """
+        client_base_url = "/experimental/textanalysis"
+        return self._create_resource_container(name, client_base_url, resources_zip_path)
+
+    @experimental_api
+    def _create_resource_container(self, name: str, base_url: str, resources_zip_path: Optional[Union[Path, str]] = None) -> ResourceContainer:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use respective public create_resource_container() method instead.
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        container_url = f"{base_url}/containers"
+        request_params = {"containerName": name}
+        if resources_zip_path is None:
+            response = self.__request_with_json_response("post", container_url, params=request_params)
+        else:
+            if isinstance(resources_zip_path, str):
+                resources_zip_path = Path(resources_zip_path)
+            with open(resources_zip_path, 'rb') as data:
+                response = self.__request_with_json_response(
+                    "post",
+                    container_url,
+                    params=request_params,
+                    files={"zippedResourceContainer": ("zippedResourceContainer", data)}
+                )
+        if response["errorMessages"]:
+            raise Exception(
+                f"Error during resource container creation {response['errorMessages']}"
+            )
+        resource_container = response["payload"]
+        return ResourceContainer(self, name=resource_container["containerName"], scope=resource_container["scope"], base_url=container_url)
+
+    @experimental_api
+    def _list_container_resources(self, container_name: str, base_url: str) -> List[str]:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use ResourceContainer.list_resources() instead.
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        response = self.__request_with_json_response("get", f"{base_url}/{container_name}")
+        if response["errorMessages"]:
+            raise Exception(
+                f"Error while listing resources in container {container_name}: {response['errorMessages']}"
+            )
+        payload = response["payload"]
+        resources = payload["resources"]
+        return [resource["relativePath"] for resource in resources]
+
+    @experimental_api
+    def _export_resource(self, target_path: Union[str, Path], container_name: str, base_url: str, resource_path: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use ResourceContainer.export_resource() instead.
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        if isinstance(target_path, str):
+            target_path = Path(target_path)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(target_path, "wb") as resource_file:
+            resource = self.__request_with_bytes_response("get", f"{base_url}/{container_name}/resources",
+                                                          params={"relativePath": resource_path})
+            resource_file.write(resource)
+
+    def _upsert_resource(self, resource_file_path: Union[str, Path], container_name: str, base_url: str, resource_path: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use ResourceContainer.upsert_resource() instead.
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        request_params = {"relativePath": resource_path}
+        request_url = f"{base_url}/{container_name}/resources"
+        if isinstance(resource_file_path, str):
+            resource_file_path = Path(resource_file_path)
+        with resource_file_path.open("rb") as data:
+            response = self.__request_with_json_response(
+                "post",
+                request_url,
+                params=request_params,
+                files={"resource": ("resource", data)}
+            )
+            if response["errorMessages"]:
+                raise Exception(
+                    f"Error during resource upload {response['errorMessages']}"
+                )
+
+    @experimental_api
+    def _export_container_resources(self, target_zip_path: Union[Path, str], container_name: str, base_url: str) -> None:
+        """
+        HIGHLY EXPERIMENTAL API - may soon change or disappear.
+        Use ResourceContainer.export_resources() instead.
+        """
+        build_version = self.get_build_info()
+        if build_version["platformVersion"] < "8.23":
+            raise OperationNotSupported(
+                f"The container resource API is only supported for platform versions >= 8.23, but current platform is {build_version['platformVersion']}.")
+        if isinstance(target_zip_path, str):
+            target_zip_path = Path(target_zip_path)
+
+        target_zip_path.parent.mkdir(parents=True, exist_ok=True)
+        request_headers = {HEADER_CONTENT_TYPE: MEDIA_TYPE_APPLICATION_JSON, HEADER_ACCEPT: MEDIA_TYPE_APPLICATION_ZIP}
+        with open(target_zip_path, "wb") as zip_file:
+            resources = self.__request_with_bytes_response("get", f"{base_url}/{container_name}", headers=request_headers)
+            zip_file.write(resources)
+
+    @experimental_api
+    @deprecated("Use resource container API instead.")
     def list_resources(self) -> List[str]:
         """
         List the resources that are globally available.
@@ -2054,6 +2374,7 @@ class Client:
         return self._list_resources()["files"]
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def download_resources(self, target_zip_path: Union[Path, str]) -> None:
         """
         Download Client-level pipeline resources and store in given path.
@@ -2062,6 +2383,7 @@ class Client:
         self._download_resources(target_zip_path)
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def delete_resources(self) -> None:
         """
         Delete the global resources.
@@ -2070,6 +2392,7 @@ class Client:
         self._delete_resources()
 
     @experimental_api
+    @deprecated("Use resource container API instead.")
     def upload_resources(
         self, source: Union[IO, Path, str], path_in_zip: Union[Path, str] = ""
     ) -> List[str]:
@@ -2655,7 +2978,6 @@ class Client:
                 ),
                 ENCODING_UTF_8,
             )
-
 
     @experimental_api
     def _export_analysis_result_typesystem(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,6 +113,131 @@ def test_upload_license(client, requests_mock):
     assert license_info == payload
 
 
+def test_list_resource_containers_not_supported(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.6.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.22.0"
+            },
+            "errorMessages": []
+        },
+    )
+    with pytest.raises(OperationNotSupported):
+        client.list_resource_containers()
+
+
+def test_list_resource_containers(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/containers",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "containers": [
+                    {
+                        "name": "container",
+                        "scope": "GLOBAL"
+                    }
+                ]
+            },
+            "errorMessages": []
+        }
+    )
+
+    actual_containers = client.list_resource_containers()
+    assert len(actual_containers) == 1
+    actual_container = actual_containers[0]
+    assert actual_container.name == "container"
+
+
+def test_create_resource_container(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.post(
+        f"{API_EXPERIMENTAL}/textanalysis/containers",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "containerName": "container",
+                "scope": "GLOBAL",
+                "resources": [
+                    {
+                        "relativePath": "text3.txt"
+                    },
+                    {
+                        "relativePath": "text2.txt"
+                    },
+                    {
+                        "relativePath": "text1.txt"
+                    },
+                    {
+                        "relativePath": "sub/text4.txt"
+                    }
+                ]
+            },
+            "errorMessages": []
+        }
+    )
+
+    resource_zip_file = Path(TEST_DIRECTORY) / "resources" / "zip_test" / "zip_test.zip"
+    actual_resource_container = client.create_resource_container("container", resource_zip_file)
+    assert actual_resource_container.name == "container"
+
+
+def test_delete_resource_container(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.delete(
+        f"{API_EXPERIMENTAL}/textanalysis/containers/container",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {},
+            "errorMessages": [],
+        }
+    )
+
+    response = client.delete_resource_container("container")
+    assert response is None
+
+
 def test_generate_api_token(client, requests_mock):
     requests_mock.post(
         f"{API_BASE}/users/admin/apitoken",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -211,33 +211,6 @@ def test_create_resource_container(client, requests_mock):
     assert actual_resource_container.name == "container"
 
 
-def test_delete_resource_container(client, requests_mock):
-    requests_mock.get(
-        f"{API_BASE}/buildInfo",
-        headers={"Content-Type": "application/json"},
-        json={
-            "payload": {
-                "specVersion": "7.7.0",
-                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
-                "platformVersion": "8.23.0"
-            },
-            "errorMessages": []
-        },
-    )
-
-    requests_mock.delete(
-        f"{API_EXPERIMENTAL}/textanalysis/containers/container",
-        headers={"Content-Type": "application/json"},
-        json={
-            "payload": {},
-            "errorMessages": [],
-        }
-    )
-
-    response = client.delete_resource_container("container")
-    assert response is None
-
-
 def test_generate_api_token(client, requests_mock):
     requests_mock.post(
         f"{API_BASE}/users/admin/apitoken",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -467,35 +467,6 @@ def test_create_resource_container(client, requests_mock):
     assert actual_resource_container.name == "container"
 
 
-def test_delete_resource_container(client, requests_mock):
-    requests_mock.get(
-        f"{API_BASE}/buildInfo",
-        headers={"Content-Type": "application/json"},
-        json={
-            "payload": {
-                "specVersion": "7.7.0",
-                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
-                "platformVersion": "8.23.0"
-            },
-            "errorMessages": []
-        },
-    )
-
-    requests_mock.delete(
-        f"{API_EXPERIMENTAL}/textanalysis/projects/test/pipelines/pipeline/containers/container",
-        headers={"Content-Type": "application/json"},
-        json={
-            "payload": {},
-            "errorMessages": [],
-        }
-    )
-
-    project = client.get_project("test")
-    pipeline = project.get_pipeline("pipeline")
-    response = pipeline.delete_resource_container("container")
-    assert response is None
-
-
 def test_analyse_texts_to_cas(client, pipeline_analyse_text_to_cas_mock):
     pipeline = Pipeline(Project(client, PROJECT_NAME), "discharge")
     file1_path = os.path.join(TEST_DIRECTORY, "resources/texts/text1.txt")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -225,34 +225,6 @@ def test_create_resource_container(client, requests_mock):
     assert actual_resource_container.name == "container"
 
 
-def test_delete_resource_container(client, requests_mock):
-    requests_mock.get(
-        f"{API_BASE}/buildInfo",
-        headers={"Content-Type": "application/json"},
-        json={
-            "payload": {
-                "specVersion": "7.7.0",
-                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
-                "platformVersion": "8.23.0"
-            },
-            "errorMessages": []
-        },
-    )
-
-    requests_mock.delete(
-        f"{API_EXPERIMENTAL}/textanalysis/projects/test/containers/container",
-        headers={"Content-Type": "application/json"},
-        json={
-            "payload": {},
-            "errorMessages": [],
-        }
-    )
-
-    project = client.get_project("test")
-    response = project.delete_resource_container("container")
-    assert response is None
-
-
 def test_exists_pipeline(client_version_6, requests_mock):
     project = client_version_6.get_project(PROJECT_NAME)
     requests_mock.get(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -142,6 +142,117 @@ def test_list_annotators(client_version_7, requests_mock):
     assert annotators[1]["displayName"] == "DummyAnnotator2"
 
 
+def test_list_resource_containers(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/test/containers",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "containers": [
+                    {
+                        "name": "container",
+                        "scope": "GLOBAL"
+                    }
+                ]
+            },
+            "errorMessages": []
+        }
+    )
+
+    project = client.get_project("test")
+    actual_containers = project.list_resource_containers()
+    assert len(actual_containers) == 1
+    actual_container = actual_containers[0]
+    assert actual_container.name == "container"
+
+
+def test_create_resource_container(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.post(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/test/containers",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "containerName": "container",
+                "scope": "GLOBAL",
+                "resources": [
+                    {
+                        "relativePath": "text3.txt"
+                    },
+                    {
+                        "relativePath": "text2.txt"
+                    },
+                    {
+                        "relativePath": "text1.txt"
+                    },
+                    {
+                        "relativePath": "sub/text4.txt"
+                    }
+                ]
+            },
+            "errorMessages": []
+        }
+    )
+
+    resource_zip_file = Path(TEST_DIRECTORY) / "resources" / "zip_test" / "zip_test.zip"
+    project = client.get_project("test")
+    actual_resource_container = project.create_resource_container("container", resource_zip_file)
+    assert actual_resource_container.name == "container"
+
+
+def test_delete_resource_container(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.delete(
+        f"{API_EXPERIMENTAL}/textanalysis/projects/test/containers/container",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {},
+            "errorMessages": [],
+        }
+    )
+
+    project = client.get_project("test")
+    response = project.delete_resource_container("container")
+    assert response is None
+
+
 def test_exists_pipeline(client_version_6, requests_mock):
     project = client_version_6.get_project(PROJECT_NAME)
     requests_mock.get(

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -189,3 +189,29 @@ def test_delete_resource(client, requests_mock):
     resource_container = ResourceContainer(client, "container", "GLOBAL", "experimental/textanalysis/containers")
     resource_container.delete_resource("test/text1.txt")
 
+
+def test_delete_resource_container(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.delete(
+        f"{API_EXPERIMENTAL}/textanalysis/containers/container",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {},
+            "errorMessages": [],
+        }
+    )
+
+    resource_container = ResourceContainer(client, "container", "GLOBAL", "experimental/textanalysis/containers")
+    resource_container.delete()

--- a/tests/test_resource_container.py
+++ b/tests/test_resource_container.py
@@ -1,0 +1,191 @@
+#
+# Copyright (c) 2024 Averbis GmbH.
+#
+# This file is part of Averbis Python API.
+# See https://www.averbis.com for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+import logging
+import os
+from pathlib import Path
+
+from averbis import ResourceContainer
+from tests.fixtures import *
+
+TEST_DIRECTORY = os.path.dirname(__file__)
+
+logging.basicConfig(level=logging.INFO)
+
+
+def test_list_resources(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/containers/container",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "containerName": "container",
+                "scope": "GLOBAL",
+                "resources": [
+                    {
+                        "relativePath": "text3.txt"
+                    },
+                    {
+                        "relativePath": "text2.txt"
+                    },
+                    {
+                        "relativePath": "text1.txt"
+                    },
+                    {
+                        "relativePath": "sub/text4.txt"
+                    }
+                ]
+            },
+            "errorMessages": []
+        }
+    )
+
+    resource_container = ResourceContainer(client, "container", "GLOBAL", "experimental/textanalysis/containers")
+    actual_resources = resource_container.list_resources()
+    assert len(actual_resources) == 4
+    assert "text3.txt" in actual_resources
+    assert "text2.txt" in actual_resources
+    assert "text1.txt" in actual_resources
+    assert "sub/text4.txt" in actual_resources
+
+
+def test_export_resources(tmp_path, client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    example_text = "some text"
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/containers/container",
+        headers={"Content-Type": "application/zip"},
+        text=example_text,
+    )
+
+    target_zip_file = tmp_path / "target_zip.zip"
+    resource_container = ResourceContainer(client, "container", "GLOBAL", "experimental/textanalysis/containers")
+    resource_container.export_resources(target_zip_file)
+
+    assert target_zip_file.exists()
+    assert example_text == target_zip_file.read_text()
+
+
+def test_export_resource(tmp_path, client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    example_text = "some text"
+    requests_mock.get(
+        f"{API_EXPERIMENTAL}/textanalysis/containers/container/resources",
+        text=example_text,
+    )
+
+    target_file = tmp_path / "target.txt"
+    resource_container = ResourceContainer(client, "container", "GLOBAL", "experimental/textanalysis/containers")
+    resource_container.export_resource(target_file, "test/target.txt")
+
+    assert target_file.exists()
+    assert example_text == target_file.read_text()
+
+
+def test_upsert_resource(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.post(
+        f"{API_EXPERIMENTAL}/textanalysis/containers/container/resources",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {},
+            "errorMessages": [],
+        }
+    )
+
+    resource_file = Path(TEST_DIRECTORY) / "resources" / "texts" / "text1.txt"
+    resource_container = ResourceContainer(client, "container", "GLOBAL", "experimental/textanalysis/containers")
+    resource_container.upsert_resource(resource_file, "test/text1.txt")
+
+
+def test_delete_resource(client, requests_mock):
+    requests_mock.get(
+        f"{API_BASE}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {
+                "specVersion": "7.7.0",
+                "buildNumber": "branch: main f2731e315ee137cf94c48e5f2fa431777fe49cef",
+                "platformVersion": "8.23.0"
+            },
+            "errorMessages": []
+        },
+    )
+
+    requests_mock.delete(
+        f"{API_EXPERIMENTAL}/textanalysis/containers/container/resources",
+        headers={"Content-Type": "application/json"},
+        json={
+            "payload": {},
+            "errorMessages": [],
+        }
+    )
+
+    resource_container = ResourceContainer(client, "container", "GLOBAL", "experimental/textanalysis/containers")
+    resource_container.delete_resource("test/text1.txt")
+


### PR DESCRIPTION
**What's in the PR?**

- resource methods on client, project, pipeline level
- resourcecontainer for specific resource interactions and container export
- deprecated old resource api methods

- contains unit tests

**How to test manually?**

Example usage:

```
resource_container_file_path = Path("data") / "test_resource.zip"

hd_client = Client(PRODUCT_URL, api_token=API_TOKEN)
project = hd_client.get_project(PROJECT_NAME)
pipeline = project.get_pipeline(PIPELINE_NAME)

test_resource = pipeline.create_resource_container("test-resource", resource_container_file_path)
print(f"Containers: {[c.name for c in pipeline.list_resource_containers()]}")
print(f"Resources in {test_resource}: {test_resource.list_resources()}")
test_resource.export_resources(target_path)
test_resource.export_resource(target_path_single_resource, "test/res.txt")
test_resource.upsert_resource(resource_file_path, "test/res2.txt")
print(f"Resources in {test_resource}: {test_resource.list_resources()}")

```