### PR TITLE
Issue #166: Enable FHIR response for analyze_text endpoint

### DIFF
--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -441,7 +441,7 @@ class Pipeline:
         annotation_types: Union[None, str, List[str]] = None,
         language: Optional[str] = None,
         timeout: Optional[float] = None
-    ) -> List[Dict]:
+    ) -> List[dict]:
         """
         Analyze the given text or text file using the pipeline.
 
@@ -588,8 +588,7 @@ class Pipeline:
             :param language:         Optional parameter setting the language of the document, e.g. "en" or "de".
             :param timeout:          Optional timeout (in seconds) specifying how long the request is waiting for a server response.
 
-            :return: The raw payload of the server response. Future versions of this library may return a better-suited
-                     representation.
+            :return: Analyzed document as a Cas
         """
         # noinspection PyProtectedMember
         cas_xmi = self.project.client._analyse_text(

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -3043,7 +3043,7 @@ class Client:
         timeout: Optional[float] = None,
         content_type: Optional[str] = MEDIA_TYPE_TEXT_PLAIN_UTF8,
         accept_type: Optional[str] = MEDIA_TYPE_APPLICATION_JSON
-    ) -> Union[list[dict], dict, bytes]:
+    ) -> Union[List[dict], dict, bytes]:
 
         if accept_type != MEDIA_TYPE_APPLICATION_JSON or content_type != MEDIA_TYPE_TEXT_PLAIN_UTF8:
             build_version = self.get_build_info()

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -3043,7 +3043,7 @@ class Client:
         timeout: Optional[float] = None,
         content_type: Optional[str] = MEDIA_TYPE_TEXT_PLAIN_UTF8,
         accept_type: Optional[str] = MEDIA_TYPE_APPLICATION_JSON
-    ) -> dict | bytes:
+    ) -> Union[dict, bytes]:
 
         if accept_type != MEDIA_TYPE_APPLICATION_JSON or content_type != MEDIA_TYPE_TEXT_PLAIN_UTF8:
             build_version = self.get_build_info()
@@ -3074,7 +3074,7 @@ class Client:
                       language: Optional[str] = None,
                       timeout: Optional[float] = None,
                       content_type: Optional[str] = MEDIA_TYPE_FHIR_JSON,
-                      accept_type: Optional[str] = MEDIA_TYPE_APPLICATION_JSON) -> bytes | dict:
+                      accept_type: Optional[str] = MEDIA_TYPE_APPLICATION_JSON) -> Union[bytes, dict]:
         url = f"/v1/textanalysis/projects/{project}/pipelines/{pipeline}/analyseText"
         request_params = {"annotationTypes": self._preprocess_annotation_types(annotation_types), "language": language}
         request_headers = {HEADER_CONTENT_TYPE: content_type, HEADER_ACCEPT: accept_type}
@@ -3097,7 +3097,7 @@ class Client:
         )
 
     @staticmethod
-    def _create_request_data(content_type: str | None, source: Union[Path, IO, str, dict]) -> IO:
+    def _create_request_data(content_type: Optional[str], source: Union[Path, IO, str, dict]) -> IO:
         if isinstance(source, IO):
             return source
         if isinstance(source, Path):

--- a/averbis/core/_rest_client.py
+++ b/averbis/core/_rest_client.py
@@ -441,7 +441,7 @@ class Pipeline:
         annotation_types: Union[None, str, List[str]] = None,
         language: Optional[str] = None,
         timeout: Optional[float] = None
-    ) -> list[dict]:
+    ) -> List[Dict]:
         """
         Analyze the given text or text file using the pipeline.
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -114,6 +114,15 @@ def requests_mock_platform_7(requests_mock):
     )
 
 
+@pytest.fixture()
+def requests_mock_platform_8_17(requests_mock):
+    requests_mock.get(
+        f"{URL_BASE_ID + '/rest/v1'}/buildInfo",
+        headers={"Content-Type": "application/json"},
+        json={"payload": {"specVersion": "7.13.0", "buildNumber": "", "platformVersion": "8.17.0"}, "errorMessages": []},
+    )
+
+
 ## Different clients based on the above platforms
 
 # Tests that should work for all platform versions
@@ -167,5 +176,9 @@ def client_version_6_17_platform_6_50(requests_mock_platform_6_50):
 def client_version_7(requests_mock_platform_7):
     return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)
 
+
+@pytest.fixture()
+def client_version_7_3_platform_8_17(requests_mock_platform_8_17):
+    return Client(URL_BASE_ID, api_token=TEST_API_TOKEN)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -463,7 +463,7 @@ def test_analyse_fhir_to_cas(client_version_7_3_platform_8_17, requests_mock):
 def test_analyse_fhir_to_json(client_version_7_3_platform_8_17, requests_mock):
     def callback(request, _content):
         request_text = request.json()
-        return {"payload": {"text": request_text}}
+        return {"payload": [request_text]}
 
     requests_mock.post(
         f"{API_BASE}/textanalysis/projects/{PROJECT_NAME}/pipelines/discharge/analyseText",
@@ -475,7 +475,7 @@ def test_analyse_fhir_to_json(client_version_7_3_platform_8_17, requests_mock):
     text = "The patient has a fever"
     fhir = _create_fhir(text.encode("utf-8"))
     result = pipeline.analyse_fhir(source=fhir)
-    assert result["text"] == fhir
+    assert result[0] == fhir
 
 
 def _create_fhir(text: bytes):


### PR DESCRIPTION
**What's in the PR?**

- support fhir format and update other supported formats for the analyse_text endpoint

**How to test manually?**
E..g analyse text and return fhir:

```
hd_client = Client(url, api_token=API_TOKEN)
project = hd_client.create_project(project_name, exist_ok=True)
pipeline = project.get_pipeline(pipeline_name)
pipeline.analyse_text_to_fhir(source="The patient has a fever.")
```

- [x] PR contains unit tests

