### PR TITLE
Branch and Path Triggers Updated:

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,33 +2,56 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [ "main", "release/**" ]
+    paths-ignore: [ ".github/**" ]
   pull_request:
-    branches: [main]
+    branches: [ "main", "release/**" ]
+    paths-ignore: [ ".github/**" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
         python-version: [3.8, 3.9, 3.10.x, 3.11, 3.12]
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        ref: ${{ github.head_ref || github.ref }}
+        lfs: true
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         pip install --upgrade -e .[test]
+
     - name: Lint with mypy
       run: |
         python -m mypy averbis
+
     - name: Run tests
       run: |
         pytest --cov=./ --cov-report=xml
+
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      if: github.event_name == 'push'
+      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
         file: ./coverage.xml
         env_vars: OS,PYTHON


### PR DESCRIPTION
**What's in the PR**
- Update GitHub Actions workflow to trigger on main and release branches, including PRs
- Add concurrency control and explicit permissions to workflow
- Pin action versions for checkout, setup-python, and codecov
- Improve workflow readability and maintainability
- Restrict Codecov upload to push events only.

**How to test manually**
* Check if the workflows work

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
