### PR TITLE
Issue 203: Export enum TextanalysisMode

### DIFF
--- a/averbis/__init__.py
+++ b/averbis/__init__.py
@@ -29,6 +29,7 @@ from .core import (
     EvaluationConfiguration,
     ResourceContainer,
     ExtendedRequestException,
+    TextanalysisMode
 )
 
 __all__ = [
@@ -43,4 +44,5 @@ __all__ = [
     "Process",
     "ResourceContainer",
     "ExtendedRequestException",
+    "TextanalysisMode"
 ]

--- a/averbis/core/__init__.py
+++ b/averbis/core/__init__.py
@@ -34,6 +34,7 @@ from ._rest_client import (
     Process,
     EvaluationConfiguration,
     ExtendedRequestException,
+    TextanalysisMode,
     DOCUMENT_IMPORTER_CAS,
     DOCUMENT_IMPORTER_SOLR,
     DOCUMENT_IMPORTER_TEXT,
@@ -69,6 +70,7 @@ __all__ = [
     "Pear",
     "Process",
     "EvaluationConfiguration",
+    "TextanalysisMode"
     "DOCUMENT_IMPORTER_CAS",
     "DOCUMENT_IMPORTER_SOLR",
     "DOCUMENT_IMPORTER_TEXT",


### PR DESCRIPTION
**What's in the PR**
- make textanalysis mode enum accessible

**How to test manually**
* test an import with textanalysis mode after installing the python client with e.g.
```
from averbis import TextanalysisMode

...

collection.import_documents(doc_path, textanalysis_mode=TextanalysisMode.REMOVE_RESULTS)
```

